### PR TITLE
A few smaller fixes to CDA generation and its unit tests

### DIFF
--- a/country-a-service/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
+++ b/country-a-service/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
@@ -12,7 +12,7 @@ codeSystem="${value.codeSystem}"<#rt>
 root="${id.root}"<#rt>
 <#if id.extension??> extension="${id.extension}"</#if><#rt>
 </#macro>
-<!--
+<#--
  The following macro uses the string "__NULL__" as a replacement for a pure null value
  This is caused by the freemarker handling of null values as input to macros, and is chosen, since we do not expect
  any of the actual values to match this string. Treat it is a null value, only one that can be a default for the macro"

--- a/country-a-service/cda-generator/src/test/java/dk/sds/ncp/cda/EPrescriptionL1GeneratorTest.java
+++ b/country-a-service/cda-generator/src/test/java/dk/sds/ncp/cda/EPrescriptionL1GeneratorTest.java
@@ -1,28 +1,26 @@
 package dk.sds.ncp.cda;
 
+import dk.nsp.epps.testing.shared.FmkResponseStorage;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-
 public class EPrescriptionL1GeneratorTest {
     @Test
-    void generateTest() throws IOException {
-        var model = EPrescriptionL3MapperTest.getModel();
-        var pdfFields = EPrescriptionL1Mapper.map(model);
-        var pdf = EPrescriptionL1Generator.generate(pdfFields);
+    void generateTest() throws Exception {
+        var cpr = "0201909309";
+        var fmkResponse = FmkResponseStorage.storedPrescriptions(cpr);
+        var modelL3 = EPrescriptionL3Mapper.model(fmkResponse, 0);
+        var modelL1 = EPrescriptionL1Mapper.map(modelL3);
+        var pdf = EPrescriptionL1Generator.generate(modelL1);
         Assertions.assertNotNull(pdf);
 
-        //Write test output files
-        File directory = new File("temp/");
-        if(!directory.exists()){
-            directory.mkdirs();
-        }
-        try (FileOutputStream fos = new FileOutputStream("temp/pdflevel1-test.pdf")){
-            fos.write(pdf);
-        }
+        // Write PDF to disk for debugging purposes
+//        java.nio.file.Files.write(
+//            java.nio.file.Path.of("temp/cda-eprescription-l1-" + cpr + ".pdf"),
+//            pdf,
+//            java.nio.file.StandardOpenOption.CREATE,
+//            java.nio.file.StandardOpenOption.TRUNCATE_EXISTING
+//        );
     }
 
     @Test

--- a/country-a-service/cda-generator/src/test/java/dk/sds/ncp/cda/EPrescriptionL3GeneratorTest.java
+++ b/country-a-service/cda-generator/src/test/java/dk/sds/ncp/cda/EPrescriptionL3GeneratorTest.java
@@ -46,5 +46,13 @@ class EPrescriptionL3GeneratorTest {
 
         // 3. Test model/schematron via gazelle
         // TODO?
+
+        // write to file for debugging:
+//         java.nio.file.Files.writeString(
+//             java.nio.file.Path.of("temp/cda-eprescription-" + cpr + ".xml"),
+//             xmlString,
+//             java.nio.file.StandardOpenOption.CREATE,
+//             java.nio.file.StandardOpenOption.TRUNCATE_EXISTING
+//         );
     }
 }


### PR DESCRIPTION
- Don't include macro-comment in generated CDA
- Don't always write PDF to disk
- Reintroduce "write to disk" comment in L3 unit test