### PR TITLE
Fix Undo Effectuation test

### DIFF
--- a/country-a-service/.idea/misc.xml
+++ b/country-a-service/.idea/misc.xml
@@ -4,8 +4,14 @@
   <component name="MavenProjectsManager">
     <option name="originalFiles">
       <list>
+        <option value="$PROJECT_DIR$/testing-shared/pom.xml" />
         <option value="$PROJECT_DIR$/pom.xml" />
       </list>
+    </option>
+    <option name="ignoredFiles">
+      <set>
+        <option value="$PROJECT_DIR$/country-b-mock/pom.xml" />
+      </set>
     </option>
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="temurin-21" project-jdk-type="JavaSDK" />

--- a/country-a-service/epps-application/src/main/java/dk/nsp/epps/controller/PrescriptionController.java
+++ b/country-a-service/epps-application/src/main/java/dk/nsp/epps/controller/PrescriptionController.java
@@ -1,6 +1,7 @@
 package dk.nsp.epps.controller;
 
 import dk.nsp.epps.Utils;
+import dk.nsp.epps.client.TestIdentities;
 import dk.nsp.epps.ncp.api.DisardDispensationRequestDto;
 import dk.nsp.epps.ncp.api.DocumentAssociationForEPrescriptionDocumentMetadataDto;
 import dk.nsp.epps.ncp.api.EpsosDocumentDto;
@@ -34,7 +35,7 @@ public class PrescriptionController {
         @Valid @RequestBody PostFindEPrescriptionDocumentsRequestDto params
     ) throws JAXBException, IOException, InterruptedException {
         var filter = new PrescriptionFilter(params.getDocumentId(), params.getCreatedBefore(), params.getCreatedAfter());
-        return prescriptionService.findEPrescriptionDocuments(params.getPatientId(), filter);
+        return prescriptionService.findEPrescriptionDocuments(params.getPatientId(), filter, TestIdentities.apotekerChrisChristoffersen);
     }
 
     @PostMapping(path = "/api/fetch-document/")
@@ -42,14 +43,14 @@ public class PrescriptionController {
         @Valid @RequestBody PostFetchDocumentRequestDto params
     ) throws JAXBException {
         var filter = new PrescriptionFilter(params.getDocumentId(), params.getCreatedBefore(), params.getCreatedAfter());
-        return prescriptionService.getPrescriptions(params.getPatientId(), filter);
+        return prescriptionService.getPrescriptions(params.getPatientId(), filter, TestIdentities.apotekerChrisChristoffersen);
     }
 
     @PostMapping(path = "/api/edispensation/submit")
     public void submitDispensation(
         @Valid @RequestBody SubmitDispensationRequestDto request
     ) throws SAXException, MapperException {
-        prescriptionService.submitDispensation(request.getPatientId(), Utils.readXmlDocument(request.getDocument()));
+        prescriptionService.submitDispensation(request.getPatientId(), Utils.readXmlDocument(request.getDocument()), TestIdentities.apotekerChrisChristoffersen);
     }
 
     @PostMapping(path = "/api/edispensation/discard")
@@ -57,6 +58,6 @@ public class PrescriptionController {
         @Valid @RequestBody DisardDispensationRequestDto request
     ) throws SAXException, JAXBException, MapperException, XPathExpressionException {
         prescriptionService.undoDispensation(request.getDisardDispenseDetails()
-            .getPatientId(), Utils.readXmlDocument(request.getDispensationToDiscard().getDocument()));
+            .getPatientId(), Utils.readXmlDocument(request.getDispensationToDiscard().getDocument()), TestIdentities.apotekerChrisChristoffersen);
     }
 }

--- a/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/PrescriptionService.java
+++ b/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/PrescriptionService.java
@@ -118,11 +118,11 @@ public class PrescriptionService {
         String cpr = PatientIdMapper.toCpr(patientId);
         final var request = GetPrescriptionRequestType.builder()
             .withPersonIdentifier().withSource("CPR").withValue(cpr).end()
-            .withIncludeOpenPrescriptions().end()
+            .withIncludeAllPrescriptions().end()
             .withIncludeEffectuations(true)
             .build();
         log.debug("Looking up info for {}", cpr);
-        GetPrescriptionResponseType fmkResponse = fmkClient.getPrescription(request, TestIdentities.apotekerJeppeMoeller);
+        GetPrescriptionResponseType fmkResponse = fmkClient.getPrescription(request, TestIdentities.apotekerJeppeMoeller,true);
 
         UndoEffectuationRequestType undoEffectuationRequest = dispensationMapper.createUndoEffectuationRequest(patientId, cdaToDiscard, fmkResponse);
         UndoEffectuationResponseType undoResponse = fmkClient.undoEffectuation(undoEffectuationRequest, TestIdentities.apotekerJeppeMoeller); //TODO We should probably not use static identities here

--- a/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/PrescriptionService.java
+++ b/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/PrescriptionService.java
@@ -123,10 +123,10 @@ public class PrescriptionService {
             .withIncludeEffectuations(true)
             .build();
         log.debug("Looking up info for {}", cpr);
-        GetPrescriptionResponseType fmkResponse = fmkClient.getPrescription(request, caller,true);
+        GetPrescriptionResponseType fmkResponse = fmkClient.getPrescriptionWithConsent(request, caller);
 
         UndoEffectuationRequestType undoEffectuationRequest = dispensationMapper.createUndoEffectuationRequest(patientId, cdaToDiscard, fmkResponse);
-        UndoEffectuationResponseType undoResponse = fmkClient.undoEffectuation(undoEffectuationRequest, caller); //TODO We should probably not use static identities here
+        UndoEffectuationResponseType undoResponse = fmkClient.undoEffectuation(undoEffectuationRequest, caller);
 
         //Validate undone dispensation by getting the EffectuationId that has been undone
         var effectuationWasCancelled = undoResponse.getPrescription()

--- a/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/mapping/DispensationMapper.java
+++ b/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/mapping/DispensationMapper.java
@@ -239,6 +239,10 @@ public class DispensationMapper {
             // It has implications in FMK, who validates these
             return "Apoteker";
         }
+        if ("221".equals(functionCode) && "2.16.840.1.113883.2.9.6.2.7".equals(functionCodeSystem)){
+            //This is the translation of "Medical Doctor"
+            return "Læge";
+        }
 
         throw new IllegalArgumentException("Unexpected function code: " + functionCode);
     }

--- a/country-a-service/integration-tests/src/test/java/dk/nsp/epps/FmkIT.java
+++ b/country-a-service/integration-tests/src/test/java/dk/nsp/epps/FmkIT.java
@@ -77,7 +77,7 @@ public class FmkIT {
         throws JAXBException, MapperException {
         var patientId = cpr + "^^^&2.16.17.710.802.1000.990.1.500&ISO";
         var service = new PrescriptionService(Fmk.apiClient(), new EPrescriptionMapper(""), new DispensationMapper());
-        return service.undoDispensation(patientId, eDispensation);
+        return service.undoDispensation(patientId, eDispensation, TestIdentities.apotekerChrisChristoffersen);
     }
 
 

--- a/country-a-service/nsp-client/src/main/java/dk/nsp/epps/client/FmkClient.java
+++ b/country-a-service/nsp-client/src/main/java/dk/nsp/epps/client/FmkClient.java
@@ -146,20 +146,26 @@ public class FmkClient {
      * <a href="https://wiki.fmk-teknik.dk/doku.php?id=fmk:1.4.6:hent_recept">FMK documentation.</a>
      */
     public GetPrescriptionResponseType getPrescription(GetPrescriptionRequestType request, Identity caller) throws JAXBException {
-        return getPrescription(request,caller,false);
+        return makeFmkRequest(
+            fac.createGetPrescriptionRequest(request),
+            "http://www.dkma.dk/medicinecard/xml.schema/2015/06/01/E6#GetPrescription",
+            GetPrescriptionResponseType.class,
+            caller,
+            false
+        );
     }
 
     /**
      * "Hent recept".
      * <a href="https://wiki.fmk-teknik.dk/doku.php?id=fmk:1.4.6:hent_recept">FMK documentation.</a>
      */
-    public GetPrescriptionResponseType getPrescription(GetPrescriptionRequestType request, Identity caller, Boolean requiresConsent) throws JAXBException {
+    public GetPrescriptionResponseType getPrescriptionWithConsent(GetPrescriptionRequestType request, Identity caller) throws JAXBException {
         return makeFmkRequest(
             fac.createGetPrescriptionRequest(request),
             "http://www.dkma.dk/medicinecard/xml.schema/2015/06/01/E6#GetPrescription",
             GetPrescriptionResponseType.class,
             caller,
-            requiresConsent
+            true
         );
     }
 

--- a/country-a-service/nsp-client/src/main/java/dk/nsp/epps/client/FmkClient.java
+++ b/country-a-service/nsp-client/src/main/java/dk/nsp/epps/client/FmkClient.java
@@ -1,5 +1,6 @@
 package dk.nsp.epps.client;
 
+import dk.dkma.medicinecard.xml_schema._2015._06._01.ConsentHeaderType;
 import dk.dkma.medicinecard.xml_schema._2015._06._01.CreateDrugMedicationResponseType;
 import dk.dkma.medicinecard.xml_schema._2015._06._01.CreatePharmacyEffectuationResponseType;
 import dk.dkma.medicinecard.xml_schema._2015._06._01.CreatePrescriptionResponseType;
@@ -84,6 +85,15 @@ public class FmkClient {
         return new ObjectFactory().createWhitelistingHeader(header);
     }
 
+    private JAXBElement<ConsentHeaderType> getMedicineReviewConsent() {
+        final var consentHeader = ConsentHeaderType.builder().addConsent().withSource("User").withConsentType("MedicineReviewConsent").withContent("MedicineCard").end().build();
+
+        var objectFactory = new dk.dkma.medicinecard.xml_schema._2015._06._01.ObjectFactory();
+
+        return objectFactory.createConsentHeader(consentHeader);
+    }
+
+
     /**
      * "Påbegynd ekspedition".
      * <a href="https://wiki.fmk-teknik.dk/doku.php?id=fmk:1.4.6:pabegynd_ekspedition">FMK documentation.</a>
@@ -94,7 +104,8 @@ public class FmkClient {
             facE5.createStartEffectuationRequest(request),
             "http://www.dkma.dk/medicinecard/xml.schema/2015/06/01/E6#StartEffectuation",
             StartEffectuationResponseType.class,
-            caller
+            caller,
+            false
         );
     }
 
@@ -108,7 +119,8 @@ public class FmkClient {
             facE2.createCreatePharmacyEffectuationRequest(request),
             "http://www.dkma.dk/medicinecard/xml.schema/2015/06/01/E2#CreatePharmacyEffectuation",
             CreatePharmacyEffectuationResponseType.class,
-            caller
+            caller,
+            false
         );
 
     }
@@ -123,7 +135,8 @@ public class FmkClient {
             facE5.createUndoEffectuationRequest(request),
             "http://www.dkma.dk/medicinecard/xml.schema/2015/06/01/E5#UndoEffectuation",
             UndoEffectuationResponseType.class,
-            caller
+            caller,
+            false
         );
 
     }
@@ -133,11 +146,20 @@ public class FmkClient {
      * <a href="https://wiki.fmk-teknik.dk/doku.php?id=fmk:1.4.6:hent_recept">FMK documentation.</a>
      */
     public GetPrescriptionResponseType getPrescription(GetPrescriptionRequestType request, Identity caller) throws JAXBException {
+        return getPrescription(request,caller,false);
+    }
+
+    /**
+     * "Hent recept".
+     * <a href="https://wiki.fmk-teknik.dk/doku.php?id=fmk:1.4.6:hent_recept">FMK documentation.</a>
+     */
+    public GetPrescriptionResponseType getPrescription(GetPrescriptionRequestType request, Identity caller, Boolean requiresConsent) throws JAXBException {
         return makeFmkRequest(
             fac.createGetPrescriptionRequest(request),
             "http://www.dkma.dk/medicinecard/xml.schema/2015/06/01/E6#GetPrescription",
             GetPrescriptionResponseType.class,
-            caller
+            caller,
+            requiresConsent
         );
     }
 
@@ -147,7 +169,8 @@ public class FmkClient {
             "http://www.dkma.dk/medicinecard/xml.schema/2015/06/01/E2#GetMedicineCard",
             GetMedicineCardResponseType.class,
             caller,
-            requestedRole
+            requestedRole,
+            false
         );
     }
 
@@ -157,7 +180,8 @@ public class FmkClient {
             "http://www.dkma.dk/medicinecard/xml.schema/2015/06/01/E2#GetDrugMedication",
             GetDrugMedicationResponseType.class,
             caller,
-            requestedRole
+            requestedRole,
+            false
         );
     }
 
@@ -171,7 +195,8 @@ public class FmkClient {
             "http://www.dkma.dk/medicinecard/xml.schema/2015/06/01/E2#CreateDrugMedication",
             CreateDrugMedicationResponseType.class,
             caller,
-            requestedRole
+            requestedRole,
+            false
         );
     }
 
@@ -185,7 +210,8 @@ public class FmkClient {
             "http://www.dkma.dk/medicinecard/xml.schema/2015/06/01/E2#CreatePrescription",
             CreatePrescriptionResponseType.class,
             caller,
-            requestedRole
+            requestedRole,
+            false
         );
     }
 
@@ -193,9 +219,10 @@ public class FmkClient {
         JAXBElement<RequestType> request,
         String soapAction,
         Class<ResponseType> clazz,
-        Identity caller
+        Identity caller,
+        Boolean requiresMedicineCardConsent
     ) throws JAXBException {
-        return makeFmkRequest(request, soapAction, clazz, caller, PredefinedRequestedRole.APOTEKER);
+        return makeFmkRequest(request, soapAction, clazz, caller, PredefinedRequestedRole.APOTEKER, requiresMedicineCardConsent);
     }
 
     private <RequestType, ResponseType> ResponseType makeFmkRequest(
@@ -203,17 +230,24 @@ public class FmkClient {
         String soapAction,
         Class<ResponseType> clazz,
         Identity caller,
-        PredefinedRequestedRole requestedRole
+        PredefinedRequestedRole requestedRole,
+        Boolean requiresMedicineCardConsent
     ) throws JAXBException {
         log.info("Calling '{}' with a SOAP action '{}'", serviceUri, soapAction);
         final Reply reply;
+        Element[] extraHeaders;
+        if(requiresMedicineCardConsent){
+            extraHeaders = new Element[]{toElement(getWhitelistingHeader(requestedRole)), toElement(getMedicineReviewConsent())};
+        } else {
+            extraHeaders = new Element[]{toElement(getWhitelistingHeader(requestedRole))};
+        }
         try {
             reply = NspClient.request(
                 serviceUri,
                 toElement(request),
                 soapAction,
                 caller,
-                toElement(getWhitelistingHeader(requestedRole))
+                extraHeaders
             );
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
The problem was mainly the missing open prescriptions, which required us to add an extra consentheader. I have overloaded the method to keep the consent header missing if not explicitely asked for.

Additionally, the author of the CDA and the UndoRequest must be the same (or another vague error message from FMK regarding mismatching CPRs between Jeppe and Chris), so I moved the identity management out of the Prescription Service to better be able to streamline us using the same identity. This is a subject we should focus on as soon as possible, since it is currently very much in a "dev" stage, and identity management on calls will need to be streamlined and standardized in a way that will impact most FMK calls.