### PR TITLE
Undo dispensation with a database

### DIFF
--- a/country-a-service/.dockerignore
+++ b/country-a-service/.dockerignore
@@ -1,3 +1,9 @@
 **/target
 **/.env
 .git
+.dockerignore
+Dockerfile
+docker-compose.yml
+README.md
+config/
+FMK-soapui-project.xml

--- a/country-a-service/.idea/misc.xml
+++ b/country-a-service/.idea/misc.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <list size="2">
+      <item index="0" class="java.lang.String" itemvalue="org.springframework.web.bind.annotation.ExceptionHandler" />
+      <item index="1" class="java.lang.String" itemvalue="org.springframework.web.bind.annotation.RestControllerAdvice" />
+    </list>
+  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">
     <option name="originalFiles">

--- a/country-a-service/.idea/misc.xml
+++ b/country-a-service/.idea/misc.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
-    <list size="2">
-      <item index="0" class="java.lang.String" itemvalue="org.springframework.web.bind.annotation.ExceptionHandler" />
-      <item index="1" class="java.lang.String" itemvalue="org.springframework.web.bind.annotation.RestControllerAdvice" />
+    <list size="3">
+      <item index="0" class="java.lang.String" itemvalue="org.springframework.context.annotation.Bean" />
+      <item index="1" class="java.lang.String" itemvalue="org.springframework.web.bind.annotation.ExceptionHandler" />
+      <item index="2" class="java.lang.String" itemvalue="org.springframework.web.bind.annotation.RestControllerAdvice" />
     </list>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />

--- a/country-a-service/cda-generator/pom.xml
+++ b/country-a-service/cda-generator/pom.xml
@@ -37,6 +37,12 @@
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
             <version>3.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/country-a-service/config/application.yml
+++ b/country-a-service/config/application.yml
@@ -1,15 +1,12 @@
 spring:
   application:
     name: NCPeH-DK-national-connector-service
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-
-  profiles:
-    group:
-      dev: default
-      prod: default
+  datasource:
+    url: jdbc:sqlite:data/db.sqlite
+    driver-class-name: org.sqlite.JDBC
+  flyway:
+    enabled: true
+    locations: "classpath:db/migration"
 
 app:
   fmk.endpoint.url: ${FMK_ENDPOINT_URL}

--- a/country-a-service/data/.gitignore
+++ b/country-a-service/data/.gitignore
@@ -1,0 +1,3 @@
+# Directory for data files, e.g. sqlite db
+*
+!.gitignore

--- a/country-a-service/docker-compose.yml
+++ b/country-a-service/docker-compose.yml
@@ -22,5 +22,6 @@ services:
       FMK_ENDPOINT_URL: "${FMK_ENDPOINT_URL}"
     volumes:
       - ./config:/app/config:ro
+      - ./data:/app/data
     networks:
       - epps-backend

--- a/country-a-service/epps-application/pom.xml
+++ b/country-a-service/epps-application/pom.xml
@@ -67,9 +67,7 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
 					<skip>false</skip>
-					<profiles>
-						<profile>dev,localdb</profile>
-					</profiles>
+                    <workingDirectory>..</workingDirectory>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/country-a-service/epps-application/src/main/java/dk/nsp/epps/Application.java
+++ b/country-a-service/epps-application/src/main/java/dk/nsp/epps/Application.java
@@ -2,10 +2,20 @@ package dk.nsp.epps;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.time.Clock;
 
 @SpringBootApplication
+@EnableScheduling
 public class Application {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
     }
 }

--- a/country-a-service/epps-service/pom.xml
+++ b/country-a-service/epps-service/pom.xml
@@ -49,6 +49,24 @@
 			<artifactId>spring-boot-starter-web-services</artifactId>
 		</dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+           <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/country-a-service/epps-service/pom.xml
+++ b/country-a-service/epps-service/pom.xml
@@ -59,12 +59,6 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-           <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/PrescriptionService.java
+++ b/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/PrescriptionService.java
@@ -186,6 +186,8 @@ public class PrescriptionService {
                 "More than one ({}) FMK effectuations was cancelled where it should be exactly one",
                 cancelledEffectuationCount);
         }
+        log.info("Undo effectuation successful, removing undo information");
+        undoDispensationRepository.deleteByCdaId(eDispensationCdaId);
         return undoResponse;
     }
 }

--- a/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/PrescriptionService.java
+++ b/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/PrescriptionService.java
@@ -2,7 +2,6 @@ package dk.nsp.epps.service;
 
 import dk.dkma.medicinecard.xml_schema._2015._06._01.CreatePharmacyEffectuationResponseType;
 import dk.dkma.medicinecard.xml_schema._2015._06._01.GetPrescriptionRequestType;
-import dk.dkma.medicinecard.xml_schema._2015._06._01.UndoEffectuationResponseType;
 import dk.dkma.medicinecard.xml_schema._2015._06._01.e6.GetPrescriptionResponseType;
 import dk.dkma.medicinecard.xml_schema._2015._06._01.e6.PrescriptionType;
 import dk.dkma.medicinecard.xml_schema._2015._06._01.e6.StartEffectuationResponseType;
@@ -145,7 +144,7 @@ public class PrescriptionService {
                     effectuation.getEffectuationIdentifier(),
                     effectuation.getOrderIdentifier()
                 ));
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 // We should not fail the submitDispensation request here because of a database error,
                 // because the dispensation has been recorded in FMK at this point.
                 log.error("Storing undo information for dispensation failed", e);
@@ -153,7 +152,7 @@ public class PrescriptionService {
         }
     }
 
-    public UndoEffectuationResponseType undoDispensation(@NonNull String patientId, Document cdaToDiscard, Identity caller) throws JAXBException, MapperException {
+    public void undoDispensation(@NonNull String patientId, Document cdaToDiscard, Identity caller) throws JAXBException, MapperException {
         var dispensationMapper = new DispensationMapper();
         var eDispensationCdaId = dispensationMapper.cdaId(cdaToDiscard);
         var undoInfo = undoDispensationRepository.findByCdaId(eDispensationCdaId);
@@ -188,6 +187,5 @@ public class PrescriptionService {
         }
         log.info("Undo effectuation successful, removing undo information");
         undoDispensationRepository.deleteByCdaId(eDispensationCdaId);
-        return undoResponse;
     }
 }

--- a/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/undo/UndoDispensationCleanupService.java
+++ b/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/undo/UndoDispensationCleanupService.java
@@ -1,0 +1,36 @@
+package dk.nsp.epps.service.undo;
+
+import org.slf4j.Logger;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Service that periodically cleans up the undo dispensation information database.
+ */
+@Service
+public class UndoDispensationCleanupService {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(UndoDispensationCleanupService.class);
+    private final UndoDispensationRepository repository;
+    private final Clock clock;
+
+    public UndoDispensationCleanupService(UndoDispensationRepository repository, Clock clock) {
+        this.repository = repository;
+        this.clock = clock;
+    }
+
+    @Scheduled(cron = "0 0 2 * * *") // Run at 02:00 daily
+    public void cleanupOldDispensations() {
+        log.info("Running scheduled undo dispensation info cleanup...");
+        // According to the requirements:
+        // https://webgate.ec.europa.eu/fpfis/wikis/display/EHDSI/07.04.+Option+to+discard+a+previously+performed+dispensation
+        // we should not support discard dispensation after 24h.  Therefore, we get rid of
+        // all the undo information that is more than 24h old.
+        var cutoffTime = Instant.now(clock).minus(Duration.ofHours(24));
+        var deletedRows = repository.deleteOlderThan(cutoffTime);
+        log.info("Cleaned up {} row(s)", deletedRows);
+    }
+}

--- a/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/undo/UndoDispensationRepository.java
+++ b/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/undo/UndoDispensationRepository.java
@@ -108,7 +108,7 @@ public class UndoDispensationRepository {
         // sqlite stores timestamps as strings in the format 'yyyy-MM-dd HH:mm:ss'
         // see https://www.sqlite.org/lang_createtable.html, so for the comparison
         // to work, we need to format the timestamp in the same way
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        var formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         String formattedTimestamp = timestamp.atOffset(ZoneOffset.UTC).toLocalDateTime().format(formatter);
         return jdbcTemplate.update(sql, formattedTimestamp);
     }

--- a/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/undo/UndoDispensationRepository.java
+++ b/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/undo/UndoDispensationRepository.java
@@ -37,9 +37,8 @@ public class UndoDispensationRepository {
         try {
             jdbcTemplate.update(sql, dispensation.cdaIdHash(), dispensation.orderId(), dispensation.effectuationId());
         } catch (UncategorizedSQLException e) {
-            var sqlEx = e.getSQLException();
-            if (sqlEx instanceof SQLiteException
-                && ((SQLiteException) sqlEx).getResultCode().equals(SQLiteErrorCode.SQLITE_CONSTRAINT_PRIMARYKEY)) {
+            if (e.getSQLException() instanceof SQLiteException sqlEx
+                && SQLiteErrorCode.SQLITE_CONSTRAINT_PRIMARYKEY.equals(sqlEx.getResultCode())) {
                 throw new DuplicateKeyException("Primary key constraint violation", sqlEx);
             }
             throw e;
@@ -113,7 +112,7 @@ public class UndoDispensationRepository {
         return jdbcTemplate.update(sql, formattedTimestamp);
     }
 
-    private final RowMapper<UndoDispensationRow> rowMapper = (rs, _rowNo) ->
+    private final RowMapper<UndoDispensationRow> rowMapper = (rs, rowNumber) ->
         new UndoDispensationRow(
             rs.getString("cda_id_hash"),
             rs.getLong("effectuation_id"),

--- a/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/undo/UndoDispensationRepository.java
+++ b/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/undo/UndoDispensationRepository.java
@@ -1,0 +1,106 @@
+package dk.nsp.epps.service.undo;
+
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.UncategorizedSQLException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+import org.sqlite.SQLiteErrorCode;
+import org.sqlite.SQLiteException;
+
+import javax.sql.DataSource;
+import java.time.ZoneOffset;
+
+@Repository
+public class UndoDispensationRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    public UndoDispensationRepository(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    /**
+     * Inserts a new undo dispensation record into the database.
+     * The timestamp field must be null as it is automatically set by the database.
+     *
+     * @param dispensation The dispensation record to insert
+     * @throws IllegalArgumentException if the timestamp field is not null
+     */
+    public void insert(UndoDispensationRow dispensation) {
+        if (dispensation.timestamp() != null) {
+            throw new IllegalArgumentException("timestamp value should be null when inserting UndoDispensationRow");
+        }
+        String sql = "INSERT INTO undo_dispensation (cda_id_hash, order_id, effectuation_id) VALUES (?, ?, ?)";
+        try {
+            jdbcTemplate.update(sql, dispensation.cdaIdHash(), dispensation.orderId(), dispensation.effectuationId());
+        } catch (UncategorizedSQLException e) {
+            var sqlEx = e.getSQLException();
+            if (sqlEx instanceof SQLiteException
+                && ((SQLiteException) sqlEx).getResultCode().equals(SQLiteErrorCode.SQLITE_CONSTRAINT_PRIMARYKEY)) {
+                throw new DuplicateKeyException("Primary key constraint violation", sqlEx);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Finds an undo dispensation record by its CDA ID.
+     *
+     * @param cdaId The CDA ID to search for
+     * @return The found dispensation record, or null if no record exists
+     */
+    public UndoDispensationRow findByCdaId(String cdaId) {
+        return findByCdaIdHash(UndoDispensationRow.cdaIdHash(cdaId));
+    }
+
+    /**
+     * Finds an undo dispensation record by its CDA ID hash.
+     *
+     * @param cdaIdHash The hashed CDA ID to search for
+     * @return The found dispensation record, or null if no record exists
+     */
+    private UndoDispensationRow findByCdaIdHash(String cdaIdHash) {
+        String sql = "SELECT * FROM undo_dispensation WHERE cda_id_hash = ?";
+        try {
+            return jdbcTemplate.queryForObject(sql, rowMapper, cdaIdHash);
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Deletes a row from the undo_dispensation table by the CDA ID.
+     *
+     * @param cdaId The CDA ID of the dispensation to delete
+     * @throws EmptyResultDataAccessException if the deletion fails
+     */
+    public void deleteByCdaId(String cdaId) {
+        deleteByCdaIdHash(UndoDispensationRow.cdaIdHash(cdaId));
+    }
+
+    /**
+     * Deletes a row from the undo_dispensation table by the CDA ID hash.
+     *
+     * @param cdaIdHash The CDA ID hash of the dispensation to delete
+     * @throws EmptyResultDataAccessException if the deletion fails
+     */
+    public void deleteByCdaIdHash(String cdaIdHash) {
+        String sql = "DELETE FROM undo_dispensation WHERE cda_id_hash = ?";
+        var deleted = jdbcTemplate.update(sql, cdaIdHash);
+        if (deleted == 0) {
+            throw new EmptyResultDataAccessException(
+                String.format("No dispensation found with CDA ID hash '%s'", cdaIdHash),
+                1);
+        }
+    }
+
+    private final RowMapper<UndoDispensationRow> rowMapper = (rs, _rowNo) ->
+        new UndoDispensationRow(
+            rs.getString("cda_id_hash"),
+            rs.getLong("effectuation_id"),
+            rs.getLong("order_id"),
+            // sqlite doesn't store tz info on timestamps, but we know they are UTC
+            rs.getTimestamp("timestamp").toLocalDateTime().atZone(ZoneOffset.UTC).toInstant()
+        );
+}

--- a/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/undo/UndoDispensationRow.java
+++ b/country-a-service/epps-service/src/main/java/dk/nsp/epps/service/undo/UndoDispensationRow.java
@@ -1,0 +1,50 @@
+package dk.nsp.epps.service.undo;
+
+import lombok.NonNull;
+import org.apache.commons.codec.digest.DigestUtils;
+
+import java.time.Instant;
+
+/**
+ * Represents a row in the undo_dispensation table that tracks undo information for dispensations.
+ *
+ * @param cdaIdHash An SHA-256 hash of the eDispensation CDA id (to mask potential sensitive data)
+ * @param effectuationId FMK id of the effectuation that needs to be undone
+ * @param orderId FMK id of the prescription order containing the effectuation
+ * @param timestamp When this row was created in the database, populated automatically on insert
+ */
+public record UndoDispensationRow(
+    @NonNull String cdaIdHash,
+    @NonNull Long effectuationId,
+    @NonNull Long orderId,
+    Instant timestamp
+) {
+    /**
+     * Creates a new UndoDispensationRow from a CDA ID and associated effectuation and order IDs.
+     * The timestamp is set to null as it will be populated by the database on insert.
+     *
+     * @param cdaId The CDA ID of the dispensation to be hashed
+     * @param effectuationId The ID of the effectuation to undo
+     * @param orderId The ID of the prescription order containing the effectuation
+     * @return A new UndoDispensationRow with the provided information
+     */
+    public static UndoDispensationRow fromCdaId(String cdaId, Long effectuationId, Long orderId) {
+        return new UndoDispensationRow(
+            cdaIdHash(cdaId),
+            effectuationId,
+            orderId,
+            null
+        );
+    }
+
+    /**
+     * Generates a SHA-256 hash of the provided CDA ID.
+     * This method is used to mask potentially sensitive data in the original identifier.
+     *
+     * @param cdaId The CDA ID to hash
+     * @return The SHA-256 hex string of the input CDA ID
+     */
+    public static String cdaIdHash(String cdaId) {
+        return DigestUtils.sha256Hex(cdaId);
+    }
+}

--- a/country-a-service/epps-service/src/main/resources/db/migration/V1__create_table_undo_effectuation.sql
+++ b/country-a-service/epps-service/src/main/resources/db/migration/V1__create_table_undo_effectuation.sql
@@ -1,0 +1,6 @@
+CREATE TABLE undo_dispensation (
+    cda_id_hash TEXT PRIMARY KEY,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+    order_id INTEGER NOT NULL,
+    effectuation_id INTEGER NOT NULL
+);

--- a/country-a-service/epps-service/src/main/resources/db/migration/V1__initial_setup.sql
+++ b/country-a-service/epps-service/src/main/resources/db/migration/V1__initial_setup.sql
@@ -1,6 +1,0 @@
-CREATE TABLE dispensation_fmk_ids (
-    cda_id_hash TEXT PRIMARY KEY,
-    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
-    order_id TEXT NOT NULL,
-    effectuation_id TEXT NOT NULL
-);

--- a/country-a-service/epps-service/src/main/resources/db/migration/V1__initial_setup.sql
+++ b/country-a-service/epps-service/src/main/resources/db/migration/V1__initial_setup.sql
@@ -1,0 +1,6 @@
+CREATE TABLE dispensation_fmk_ids (
+    cda_id_hash TEXT PRIMARY KEY,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+    order_id TEXT NOT NULL,
+    effectuation_id TEXT NOT NULL
+);

--- a/country-a-service/epps-service/src/test/java/dk/nsp/epps/service/undo/UndoDispensationCleanupServiceTest.java
+++ b/country-a-service/epps-service/src/test/java/dk/nsp/epps/service/undo/UndoDispensationCleanupServiceTest.java
@@ -1,0 +1,53 @@
+package dk.nsp.epps.service.undo;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+
+import java.time.Clock;
+import java.time.Duration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+class UndoDispensationCleanupServiceTest {
+
+    UndoDispensationRepository undoDispensationRepository() {
+        var dataSource = new SingleConnectionDataSource("jdbc:sqlite::memory:", true);
+        // perform db migrations
+        Flyway.configure().dataSource(dataSource).load().migrate();
+        return new UndoDispensationRepository(dataSource);
+    }
+
+    @Test
+    void testCleanupOldDispensations() {
+        var repository = undoDispensationRepository();
+
+        // insert a dispensation record
+        repository.insert(UndoDispensationRow.fromCdaId("cda-id", 1L, 1L));
+
+        // verify that the undo information is not cleaned up immediately
+        var clock = Clock.systemDefaultZone();
+        var cleanupService = new UndoDispensationCleanupService(repository, clock);
+        cleanupService.cleanupOldDispensations();
+        var dispensation = repository.findByCdaId("cda-id");
+        assertThat(dispensation, is(notNullValue()));
+
+        // and also not after 23 hours
+        var clockAfterTwentyThreeHours = Clock.offset(Clock.systemDefaultZone(), Duration.ofHours(23));
+        cleanupService = new UndoDispensationCleanupService(repository, clockAfterTwentyThreeHours);
+        cleanupService.cleanupOldDispensations();
+        dispensation = repository.findByCdaId("cda-id");
+        assertThat(dispensation, is(notNullValue()));
+
+        // but after 24 hours it should be cleaned up
+        var clockAfterOneDay = Clock.offset(Clock.systemDefaultZone(), Duration.ofHours(24).plusSeconds(1));
+        cleanupService = new UndoDispensationCleanupService(repository, clockAfterOneDay);
+        cleanupService.cleanupOldDispensations();
+        dispensation = repository.findByCdaId("cda-id");
+        assertThat(dispensation, is(nullValue()));
+    }
+
+}

--- a/country-a-service/epps-service/src/test/java/dk/nsp/epps/service/undo/UndoDispensationRepositoryTest.java
+++ b/country-a-service/epps-service/src/test/java/dk/nsp/epps/service/undo/UndoDispensationRepositoryTest.java
@@ -1,0 +1,184 @@
+package dk.nsp.epps.service.undo;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UndoDispensationRepositoryTest {
+    private UndoDispensationRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        var dataSource = new SingleConnectionDataSource("jdbc:sqlite::memory:", true);
+        // perform db migrations
+        Flyway.configure().dataSource(dataSource).load().migrate();
+        repository = new UndoDispensationRepository(dataSource);
+    }
+
+    @Test
+    void testInsertAndFindByCdaIdHash() {
+        // Given
+        var dispensation = UndoDispensationRow.fromCdaId(
+            "test-cda-id",
+            123L,
+            456L
+        );
+
+        // When
+        repository.insert(dispensation);
+        var found = repository.findByCdaId("test-cda-id");
+
+        // Then
+        assertThat(found, notNullValue());
+        assertThat(found.cdaIdHash(), equalTo(dispensation.cdaIdHash()));
+        assertThat(found.orderId(), equalTo(dispensation.orderId()));
+        assertThat(found.effectuationId(), equalTo(dispensation.effectuationId()));
+        assertThat(found.timestamp(), allOf(
+            greaterThan(Instant.now().minusSeconds(3)),
+            lessThan(Instant.now().plusSeconds(3))
+        ));
+    }
+
+    @Test
+    void testFindDoesNotExist() {
+        var found = repository.findByCdaId("test-cda-id");
+        assertThat(found, is(nullValue()));
+    }
+
+
+    @Test
+    void testDeleteDoesNotExist() {
+        assertThrows(
+            EmptyResultDataAccessException.class,
+            () -> repository.deleteByCdaId("cda-id-which-does-not-exist")
+        );
+    }
+
+    @Test
+    void testDeleteByCdaIdHash() {
+        var dispensation = UndoDispensationRow.fromCdaId(
+            "test-cda-id",
+            123L,
+            456L
+        );
+        repository.insert(dispensation);
+
+        var before = repository.findByCdaId("test-cda-id");
+        repository.deleteByCdaIdHash(dispensation.cdaIdHash());
+        var after = repository.findByCdaId("test-cda-id");
+
+
+        assertThat(before.cdaIdHash(), is(dispensation.cdaIdHash()));
+        assertThat(after, is(nullValue()));
+    }
+
+    @Test
+    void testInsertWithNonNullTimestamp() {
+        // Given
+        var dispensation = new UndoDispensationRow(
+            "hash-value",
+            123L,
+            456L,
+            Instant.now()  // Non-null timestamp
+        );
+
+        // Then
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> repository.insert(dispensation)
+        );
+    }
+
+    @Test
+    void testInsertWithExtremelyLongCdaId() {
+        // Given
+        String longCdaId = "a".repeat(1000);
+        var dispensation = UndoDispensationRow.fromCdaId(
+            longCdaId,
+            123L,
+            456L
+        );
+
+        // When
+        repository.insert(dispensation);
+        var found = repository.findByCdaId(longCdaId);
+
+        // Then
+        assertThat(found, notNullValue());
+        assertThat(found.cdaIdHash(), equalTo(dispensation.cdaIdHash()));
+    }
+
+    @Test
+    void testInsertWithSpecialCharactersInCdaId() {
+        // Given
+        String specialCdaId = "test-cda-id!@#$%^&*()_+";
+        var dispensation = UndoDispensationRow.fromCdaId(
+            specialCdaId,
+            123L,
+            456L
+        );
+
+        // When
+        repository.insert(dispensation);
+        var found = repository.findByCdaId(specialCdaId);
+
+        // Then
+        assertThat(found, notNullValue());
+        assertThat(found.cdaIdHash(), equalTo(dispensation.cdaIdHash()));
+    }
+
+    @Test
+    void testInsertDuplicateCdaId() {
+        // Given
+        var dispensation1 = UndoDispensationRow.fromCdaId(
+            "test-cda-id",
+            123L,
+            456L
+        );
+        var dispensation2 = UndoDispensationRow.fromCdaId(
+            "test-cda-id",
+            789L,
+            101112L
+        );
+
+        repository.insert(dispensation1);
+        assertThrows(
+            DuplicateKeyException.class,
+            () -> repository.insert(dispensation2)
+        );
+    }
+
+    @Test
+    void testInsertWithMaxLongValues() {
+        // Given
+        var dispensation = UndoDispensationRow.fromCdaId(
+            "test-cda-id",
+            Long.MAX_VALUE,
+            Long.MAX_VALUE
+        );
+
+        // When
+        repository.insert(dispensation);
+        var found = repository.findByCdaId("test-cda-id");
+
+        // Then
+        assertThat(found, notNullValue());
+        assertThat(found.orderId(), equalTo(Long.MAX_VALUE));
+        assertThat(found.effectuationId(), equalTo(Long.MAX_VALUE));
+    }
+}

--- a/country-a-service/integration-tests/src/test/java/dk/nsp/epps/FmkIT.java
+++ b/country-a-service/integration-tests/src/test/java/dk/nsp/epps/FmkIT.java
@@ -1,18 +1,13 @@
 package dk.nsp.epps;
 
-import dk.dkma.medicinecard.xml_schema._2015._06._01.CreatePharmacyEffectuationResponseType;
 import dk.dkma.medicinecard.xml_schema._2015._06._01.GetPrescriptionRequestType;
-import dk.dkma.medicinecard.xml_schema._2015._06._01.UndoEffectuationResponseType;
-import dk.dkma.medicinecard.xml_schema._2015._06._01.e2.PrescriptionErrorType;
-import dk.dkma.medicinecard.xml_schema._2015._06._01.e6.StartEffectuationResponseType;
 import dk.nsp.epps.client.TestIdentities;
 import dk.nsp.epps.service.PrescriptionService;
-import dk.nsp.epps.service.mapping.DispensationMapper;
+import dk.nsp.epps.service.undo.UndoDispensationRepository;
 import dk.nsp.epps.testing.shared.Fmk;
-import dk.sds.ncp.cda.MapperException;
-import jakarta.xml.bind.JAXBException;
+import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.Test;
-import org.w3c.dom.Document;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,10 +15,8 @@ import java.nio.file.Path;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.blankString;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.io.FileMatchers.aReadableFile;
 
@@ -48,37 +41,12 @@ public class FmkIT {
         return cpr + "^^^&2.16.17.710.802.1000.990.1.500&ISO";
     }
 
-    private static StartEffectuationResponseType startEffectuation(Document eDispensation, String cpr)
-        throws MapperException, JAXBException {
-        var dispensationMapper = new DispensationMapper();
-        var effectuationRequest = dispensationMapper.startEffectuationRequest(patientId(cpr), eDispensation);
-
-        return Fmk.apiClient().startEffectuation(effectuationRequest, TestIdentities.apotekerChrisChristoffersen);
-
+    private static UndoDispensationRepository undoDispensationRepository() {
+        var dataSource = new SingleConnectionDataSource("jdbc:sqlite::memory:", true);
+        // perform db migrations
+        Flyway.configure().dataSource(dataSource).load().migrate();
+        return new UndoDispensationRepository(dataSource);
     }
-
-    private static CreatePharmacyEffectuationResponseType createPharmacyEffectuation(
-        Document eDispensation,
-        String cpr,
-        StartEffectuationResponseType startEffectuationResponse
-    ) throws MapperException, JAXBException {
-        var dispensationMapper = new DispensationMapper();
-
-        return Fmk.apiClient().createPharmacyEffectuation(
-            dispensationMapper.createPharmacyEffectuationRequest(
-                patientId(cpr),
-                eDispensation,
-                startEffectuationResponse),
-            TestIdentities.apotekerChrisChristoffersen);
-    }
-
-    private static UndoEffectuationResponseType undoEffectuation(Document eDispensation, String cpr)
-        throws JAXBException, MapperException {
-        var patientId = cpr + "^^^&2.16.17.710.802.1000.990.1.500&ISO";
-        var service = new PrescriptionService(Fmk.apiClient());
-        return service.undoDispensation(patientId, eDispensation, TestIdentities.apotekerChrisChristoffersen);
-    }
-
 
     /**
      * The dispensation test case is complex because:
@@ -102,22 +70,14 @@ public class FmkIT {
             is(aReadableFile()));
         var eDispensation = Utils.readXmlDocument(Files.newInputStream(eDispensationPath));
 
-        var startEffectuationResponse = startEffectuation(eDispensation, cpr);
+        var prescriptionService = new PrescriptionService(Fmk.apiClient(), undoDispensationRepository());
 
-        var prettyFailedMessages = startEffectuationResponse.getStartEffectuationFailed().stream()
-            .map(PrescriptionErrorType::getReasonText).toList();
-        assertThat("startEffectuation failures", prettyFailedMessages, is(empty()));
-        assertThat(startEffectuationResponse.getPrescription().getFirst().getOrder().getFirst(), notNullValue());
-        assertThat(startEffectuationResponse.getPrescription().getFirst().getPackageRestriction(), notNullValue());
-
-        var createPharmacyEffectuationResult = createPharmacyEffectuation(
+        // shouldn't throw:
+        prescriptionService.submitDispensation(patientId(cpr),
             eDispensation,
-            cpr,
-            startEffectuationResponse);
+            TestIdentities.apotekerChrisChristoffersen);
 
-        assertThat(createPharmacyEffectuationResult.getEffectuation(), not(empty()));
-
-        var undoResponse = undoEffectuation(eDispensation, cpr);
-        assertThat(undoResponse.getPersonIdentifier().getValue(), is(cpr));
+        // shouldn't throw:
+        prescriptionService.undoDispensation(patientId(cpr), eDispensation, TestIdentities.apotekerChrisChristoffersen);
     }
 }

--- a/country-a-service/pom.xml
+++ b/country-a-service/pom.xml
@@ -144,7 +144,6 @@
                 <groupId>org.xerial</groupId>
                 <artifactId>sqlite-jdbc</artifactId>
                 <version>3.47.0.0</version>
-                <scope>runtime</scope>
             </dependency>
 
 			<!-- Solve convergence errors -->

--- a/country-a-service/pom.xml
+++ b/country-a-service/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.5</version>
+		<version>3.4.0</version>
 		<relativePath/>
 	</parent>
 
@@ -134,6 +134,18 @@
 				<artifactId>seal</artifactId>
 				<version>2.6.25</version>
 			</dependency>
+
+            <dependency>
+                <groupId>org.flywaydb</groupId>
+                <artifactId>flyway-core</artifactId>
+                <version>11.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.xerial</groupId>
+                <artifactId>sqlite-jdbc</artifactId>
+                <version>3.47.0.0</version>
+                <scope>runtime</scope>
+            </dependency>
 
 			<!-- Solve convergence errors -->
 			<dependency>


### PR DESCRIPTION
This PR introduces a SQLite database for the country-a-service. **If and when SQLite becomes insufficient** we will simply migrate this code to another database.

Closes #69.