### PR TITLE
111: add patient medication instructions to ePrescription

### DIFF
--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
@@ -66,11 +66,11 @@ public class EPrescriptionL3Mapper {
             .signatureTime(OffsetDateTime.now())
             .parentDocumentId(prescriptionId)
             .prescriptionId(prescriptionId)
-            .entryText(prescription.getDosageText())
             .product(product(prescription))
             .packageQuantity((long) prescription.getPackageRestriction().getPackageQuantity())
             .substitutionAllowed(prescription.isSubstitutionAllowed())
-            .indicationText(indicationText);
+            .indicationText(indicationText)
+            .patientMedicationInstructions(prescription.getDosageText());
 
         if (medication.isPresent()) {
             var drugMedicationType = medication.get();

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionPdfMapper.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionPdfMapper.java
@@ -68,7 +68,7 @@ public class EPrescriptionPdfMapper {
         lines.add("");
         lines.add(model.getIndicationText());
         lines.add("");
-        lines.add(String.format("Dosering: %s", model.getEntryText()));
+        lines.add(String.format("Dosering: %s", model.getPatientMedicationInstructions()));
         return lines;
     }
 

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/EPrescriptionL3.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/EPrescriptionL3.java
@@ -58,10 +58,10 @@ public class EPrescriptionL3 {
      */
     @NonNull OffsetDateTime signatureTime;
     @NonNull CdaId parentDocumentId;
-    @NonNull String entryText;
     @NonNull Product product;
     @NonNull Long packageQuantity;
     @NonNull Boolean substitutionAllowed;
+    @NonNull String patientMedicationInstructions;
 
     public String getEffectiveTime() {
         return Utils.cdaDateTime(effectiveTime);

--- a/country-a-service/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
+++ b/country-a-service/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
@@ -132,16 +132,15 @@
                     <id <@common.cdaIdAttrs prescriptionId />/>
                     <code code="57828-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Prescriptions"/>
                     <title>Prescriptions</title>
-                    <text> <#-- TODO review -->
-                        <paragraph>
-                            <content>${ product.name }</content>
-                        </paragraph>
-                        <paragraph>
-                            <content>${ indicationText }</content>
-                        </paragraph>
-                        <paragraph>
-                            <content>${ entryText }</content>
-                        </paragraph>
+                    <text> <#-- TODO review w. semantics -->
+                        <content ID="entry-text"><#-- TODO can't use <paragraph> within content, doesn't validate. So how is this supposed to be structured? -->
+                            ${ product.name }
+                            ${ indicationText }
+                            ${ patientMedicationInstructions }
+                        </content>
+                        <content ID="product-name">${ product.name }</content>
+                        <content ID="indication-text">${ indicationText }</content>
+                        <content ID="patient-medication-instructions">${ patientMedicationInstructions }</content>
                     </text>
                     <entry typeCode="COMP">
                         <#-- I Danmark er der én ordination per recept, derfor vil der altid være netop ét "entry"-element -->
@@ -158,7 +157,7 @@
                             <#-- Globalt unikt "prescription item id" - i vores tilfælde det samme som "prescription id",
                                  da der er et 1-1 forhold. -->
                             <id <@common.cdaIdAttrs prescriptionId />/>
-                            <text>${ entryText }</text>
+                            <text><reference value="entry-text" /></text>
                             <statusCode code="active"/>
                             <effectiveTime xsi:type="IVL_TS">
                                 <@common.valueOrNullField "low" medicationStartTime  />
@@ -233,6 +232,15 @@
                                 </observation>
                             </entryRelationship>
 </#if>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="1.3.6.1.4.1.12559.11.10.1.3.1.3.12"/>
+                                    <templateId root="2.16.840.1.113883.10.20.1.49"/>
+                                    <code code="PINSTRUCT" codeSystem="1.3.6.1.4.1.19376.1.5.3.2" codeSystemName="IHEActCode"/>
+                                    <text><reference value="#patient-medication-instructions" /></text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
                         </substanceAdministration>
                     </entry>
                 </section>

--- a/country-a-service/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3MapperTest.java
+++ b/country-a-service/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3MapperTest.java
@@ -23,9 +23,9 @@ class EPrescriptionL3MapperTest {
     }
 
     @Test
-    void entryTextTest() {
+    void getPatientMedicationInstructions() {
         var model = getModel();
-        Assertions.assertNotNull(model.getEntryText());
+        Assertions.assertNotNull(model.getPatientMedicationInstructions());
     }
 
     @Test


### PR DESCRIPTION
Adds dosage text from the FMK prescription to the ePrescription.

Resolves #111.

I have tested it against the schematron, and it validates.