### PR TITLE
try fix patient medication instructions not printed

### DIFF
--- a/country-a-service/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
+++ b/country-a-service/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
@@ -272,6 +272,7 @@
                             <entryRelationship typeCode="SUBJ" inversionInd="true">
                                 <act classCode="ACT" moodCode="INT">
                                     <templateId root="1.3.6.1.4.1.12559.11.10.1.3.1.3.12"/>
+                                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.3"/><#-- IHE template root, not required, but used in the display tool -->
                                     <templateId root="2.16.840.1.113883.10.20.1.49"/>
                                     <code code="PINSTRUCT" codeSystem="1.3.6.1.4.1.19376.1.5.3.2" codeSystemName="IHEActCode"/>
                                     <text><reference value="#patient-medication-instructions" /></text>


### PR DESCRIPTION
Hygger mig lige med at finde ud af hvorfor patient medication instructions ikke bliver vist. Xpath: "n1:entryRelationship[@typeCode='SUBJ']/n1:act[n1:templateId[@root='1.3.6.1.4.1.19376.1.5.3.1.4.3'] ]/n1:text"
 
Den er taget herfra: https://ec.europa.eu/digital-building-blocks/code/projects/EHNCP/repos/ehealth/browse/cda-display-tool/xsltransformer/src/main/resources/ep/epPrescriptionItem.xsl.
 
Det er ikke samme templateId som vi sætter på. Vi bruger 1.3.6.1.4.1.12559.11.10.1.3.1.3.12. Ifølge art-decor er det også rigtigt: https://art-decor.ehdsi.eu/publication/epsos-html-20240422T073854/tmp-1.3.6.1.4.1.12559.11.10.1.3.1.3.12-2023-07-03T134024.html, og den de kigger efter er optional. Men jeg tilføjer den nu, så ser vi om ikke det virker 