### PR TITLE
don't throw error for missing product description

### DIFF
--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
@@ -338,9 +338,11 @@ public class EPrescriptionL3Mapper {
         return null;
     }
 
-    private static @NonNull String drugStrengthText(@NonNull PrescriptionType prescription) throws MapperException {
-        var text = prescription.getDrug().getStrength().getText();
-        if (text == null) throw new MapperException("Missing Text element on DrugStrength");
-        return text.getValue();
+    private static String drugStrengthText(@NonNull PrescriptionType prescription) {
+        if (prescription.getDrug() == null || prescription.getDrug().getStrength() == null ||
+            prescription.getDrug().getStrength().getText() == null ||
+            prescription.getDrug().getStrength().getText().getValue() == null)
+            return null;
+        return prescription.getDrug().getStrength().getText().getValue();
     }
 }

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Product.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Product.java
@@ -8,7 +8,7 @@ import lombok.Value;
 @Builder
 public class Product {
     @NonNull String name;
-    @NonNull String description;
+    String description;
     @NonNull CdaCode formCode;
     CdaCode packageCode;
     CdaCode packageFormCode;

--- a/country-a-service/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
+++ b/country-a-service/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
@@ -208,7 +208,9 @@
                                     <manufacturedMaterial classCode="MMAT" determinerCode="KIND">
                                         <templateId root="1.3.6.1.4.1.12559.11.10.1.3.1.3.30"/>
                                         <name>${ product.name }</name>
+<#if product.description??>
                                         <pharm:desc>${ product.description }</pharm:desc>
+</#if>
                                         <pharm:formCode <@common.cdaCodeAttrs product.formCode />/>
                                         <pharm:asContent classCode="CONT">
 <#if product.size.unit.tag == "WithCode">


### PR DESCRIPTION
It's not mandatory in CDA: https://art-decor.ehdsi.eu/publication/epsos-html-20240422T073854/tmp-1.3.6.1.4.1.12559.11.10.1.3.1.3.30-2024-04-10T101906.html