### PR TITLE
Enhance metadata for prescriptions

### DIFF
--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
@@ -153,7 +153,7 @@ public class EPrescriptionL3Mapper {
         return Product.builder()
             .drugId(codedId)
             .name(prescription.getDrug().getName())
-            .description(drugStrengthText(prescription))
+            .strength(drugStrengthText(prescription))
             .formCode(formCode)
             .size(size)
             .packageCode(packageCode)

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Product.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Product.java
@@ -10,10 +10,15 @@ public class Product {
     /// LMS drug id
     CdaCode drugId;
     @NonNull String name;
+    String strength;
     String description;
     @NonNull CdaCode formCode;
     CdaCode packageCode;
     CdaCode packageFormCode;
     @NonNull CdaCode atcCode;
     @NonNull Size size;
+
+    public String getDescription(){ //Right now, description just returns the strength
+        return getStrength();
+    }
 }

--- a/country-a-service/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3GeneratorTest.java
+++ b/country-a-service/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3GeneratorTest.java
@@ -45,7 +45,7 @@ class EPrescriptionL3GeneratorTest {
             .packageFormCode(null)
             .atcCode(epL3.getProduct().getAtcCode())
             .formCode(epL3.getProduct().getFormCode())
-            .description(epL3.getProduct().getDescription())
+            .strength(epL3.getProduct().getStrength())
             .name(epL3.getProduct().getName())
             .size(epL3.getProduct().getSize())
             .build();

--- a/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/EPrescriptionMapper.java
+++ b/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/EPrescriptionMapper.java
@@ -83,7 +83,7 @@ public class EPrescriptionMapper {
         meta.setHash("da39a3ee5e6b4b0d3255bfef95601890afd80709"); //SHA1 hash of a zero length file
         meta.setSize(0L);
 
-        // TODO Missing metadata fields as of now
+        // TODO Missing metadata fields as of 2025-04-01
         /*
         String substitutionCode;
         String substitutionDisplayName;

--- a/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/EPrescriptionMapper.java
+++ b/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/EPrescriptionMapper.java
@@ -1,11 +1,8 @@
 package dk.sundhedsdatastyrelsen.ncpeh.service.mapping;
 
 import dk.sundhedsdatastyrelsen.ncpeh.cda.EPrescriptionDocumentIdMapper;
-import dk.sundhedsdatastyrelsen.ncpeh.cda.EPrescriptionL3Generator;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.EPrescriptionL3Input;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.EPrescriptionL3Mapper;
-import dk.sundhedsdatastyrelsen.ncpeh.cda.EPrescriptionPdfGenerator;
-import dk.sundhedsdatastyrelsen.ncpeh.cda.EPrescriptionPdfMapper;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.MapperException;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.Oid;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.DocumentLevel;
@@ -16,11 +13,7 @@ import dk.sundhedsdatastyrelsen.ncpeh.ncp.api.DocumentAssociationForEPrescriptio
 import dk.sundhedsdatastyrelsen.ncpeh.ncp.api.DocumentFormatDto;
 import dk.sundhedsdatastyrelsen.ncpeh.ncp.api.EPrescriptionDocumentMetadataDto;
 import dk.sundhedsdatastyrelsen.ncpeh.service.exception.CountryAException;
-import freemarker.template.TemplateException;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.http.HttpStatus;
-
-import java.io.IOException;
 
 public class EPrescriptionMapper {
 

--- a/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/EPrescriptionMapper.java
+++ b/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/EPrescriptionMapper.java
@@ -74,12 +74,12 @@ public class EPrescriptionMapper {
         meta.setFormat(documentFormat);
         meta.setLanguage("da-DK"); //We always include danish text in free-text, so
         meta.setProductCode(model.getProduct()
-            .getDrugId()
-            .getCode()); //Is this the correct code? It seems to be the drug code, not form/etc
+            .getPackageCode()
+            .getCode()); //Varenummer
         meta.setProductName(model.getProduct().getName());
         meta.setDoseFormCode(model.getProduct()
             .getFormCode()
-            .getCode()); //Is this correct? It is the form that the dose is supposed to take, but not the actual dosage
+            .getCode());
         meta.setDoseFormName(model.getProduct().getFormCode().getDisplayName());
         meta.setConfidentiality(new ConfidentialityMetadataDto().confidentialityCode("N")
             .confidentialityDisplay("Normal"));


### PR DESCRIPTION
We will more of the metadata with the available data.

Missing is the substitutiondata, since we don't currently support substitutions (but we probably should soon).

I also adjusted the product entity, to carry a cleartext of the strength, and modified the description to just return the strength. This is done to keep the current functionality, but make it more clear that you can have either just the strength, or the description (which might eventually be expanded with other information).