### PR TITLE
change to display prescription id as id for L3 and L1

### DIFF
--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL1Mapper.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL1Mapper.java
@@ -1,21 +1,30 @@
 package dk.sundhedsdatastyrelsen.ncpeh.cda;
 
+import dk.sundhedsdatastyrelsen.ncpeh.cda.model.CdaId;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.EPrescriptionL1;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.EPrescriptionL3;
 
 import java.util.Base64;
 
-public class EPrescriptionL1Mapper {
+public final class EPrescriptionL1Mapper {
+    private EPrescriptionL1Mapper() {
+    }
+
     public static EPrescriptionL1 model(EPrescriptionL3Input input) throws MapperException {
         return model(EPrescriptionL3Mapper.model(input));
     }
 
     public static EPrescriptionL1 model(EPrescriptionL3 l3Model) throws MapperException {
-        var pdfModel = EPrescriptionPdfMapper.map(l3Model);
+        var modelWithL1Id = l3Model.toBuilder()
+            .documentId(new CdaId(
+                Oid.DK_EPRESCRIPTION_REPOSITORY_ID, EPrescriptionDocumentIdMapper.level1DocumentId(l3Model.getPrescriptionId()
+                .getExtension())))
+            .build();
+        var pdfModel = EPrescriptionPdfMapper.map(modelWithL1Id);
         var pdf = EPrescriptionPdfGenerator.generate(pdfModel);
         var base64Pdf = Base64.getEncoder().encodeToString(pdf);
         return EPrescriptionL1.builder()
-            .l3(l3Model)
+            .l3(modelWithL1Id)
             .base64EncodedDocument(base64Pdf)
             .build();
     }

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
@@ -32,7 +32,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -40,6 +39,7 @@ import java.util.stream.Stream;
 public class EPrescriptionL3Mapper {
     private EPrescriptionL3Mapper() {
     }
+
     /**
      * Map a prescription response from FMK to a CDA data model.
      */
@@ -65,7 +65,7 @@ public class EPrescriptionL3Mapper {
             prescription.getDrug().getStrength(), prescription.getDrug()
                 .getSubstances());
         var prescriptionBuilder = EPrescriptionL3.builder()
-            .documentId(new CdaId(UUID.randomUUID()))
+            .documentId(new CdaId(Oid.DK_EPRESCRIPTION_REPOSITORY_ID, EPrescriptionDocumentIdMapper.level3DocumentId(prescriptionId.getExtension())))
             .title(String.format(
                 "eHDSI ePrescription %s - %s", patient(response).getName()
                     .getFullName(), prescription.getIdentifier()))


### PR DESCRIPTION
We got an error during the testing, that the ID we sent for the metadata was not in the document we then returned afterwards. This fixes that. Remark that we are still using a catch-all oid for these ids, that should be changed later.