### PR TITLE
194: allow for "-" in patient id and check for start/end of string

### DIFF
--- a/NCP/smp-files/InternationalSearch_DK.xml
+++ b/NCP/smp-files/InternationalSearch_DK.xml
@@ -9,7 +9,7 @@
          <ism:identifier type="NORMAL">
             <ism:id contextualDescription="nationalIdentityCardNumber"
                domain="1.2.208.176.1.2"
-               format="[0-9]{10}"
+               format="^\d{6}-?\d{4}$"
                label="label.ism.nationalIdentityCardNumber"
                mandatory="true" />
          </ism:identifier>

--- a/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/PatientIdMapper.java
+++ b/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/PatientIdMapper.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
  * represents a Danish CPR number.
  */
 public final class PatientIdMapper {
-    private static final String regexPattern = "(\\d{10})(?:\\^{3}&" + Oid.DK_CPR.value + "&ISO)?";
+    private static final String regexPattern = "^(\\d{6}-?\\d{4})(?:\\^{3}&" + Oid.DK_CPR.value + "&ISO)?";
     private static final Pattern patientIdPattern = Pattern.compile(regexPattern);
 
     private PatientIdMapper() {
@@ -33,6 +33,6 @@ public final class PatientIdMapper {
         if (!matcher.matches()) {
             throw new DataRequirementException("'" + patientId + "' doesn't match any of the expected patterns");
         }
-        return matcher.group(1);
+        return matcher.group(1).replace("-", "");
     }
 }


### PR DESCRIPTION
This because Danish patient IDs can have a dash in them.

Closes #194 