### PR TITLE
handle when specialization is an empty string

### DIFF
--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
@@ -270,7 +270,7 @@ public class EPrescriptionL3Mapper {
                 Optional.ofNullable(authorization.getSpeciale1()),
                 Optional.ofNullable(authorization.getSpeciale2()),
                 Optional.ofNullable(authorization.getSpeciale3()))
-            .filter(Optional::isPresent)
+            .filter(spe -> !spe.orElse("").trim().isEmpty())
             .map(Optional::get)
             .toList();
 


### PR DESCRIPTION
This is to avoid showing ",," as specialization.