### PR TITLE
193: throw if dispensing magistral drugs

### DIFF
--- a/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PrescriptionService.java
+++ b/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PrescriptionService.java
@@ -221,9 +221,11 @@ public class PrescriptionService {
                 .filter(p -> p.getIdentifier() == prescriptionId)
                 .findFirst()
                 .orElseThrow(() -> new CountryAException(HttpStatus.NOT_FOUND, "Could not find prescription to dispense"));
-            var isDispensable = DispensationAllowed.isDispensationAllowed(lmsDataLookupService.getLms02EntryFromPackageNumber(prescription.getPackageRestriction()
-                .getPackageNumber()
-                .getValue()));
+            var isDispensable = DispensationAllowed.isDispensationAllowed(
+                prescription,
+                lmsDataLookupService.getLms02EntryFromPackageNumber(prescription.getPackageRestriction()
+                    .getPackageNumber()
+                    .getValue()));
             if (!isDispensable) {
                 throw new CountryAException(HttpStatus.BAD_REQUEST, "Prescription is not allowed to be dispensed");
             }

--- a/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/EPrescriptionMapper.java
+++ b/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/EPrescriptionMapper.java
@@ -123,7 +123,7 @@ public class EPrescriptionMapper {
             prescription.getDrug().getForm().getCode().getValue(),
             prescription.getDrug().getForm().getText(),
             EPrescriptionL3Mapper.drugStrengthText(prescription),
-            DispensationAllowed.isDispensationAllowed(lms02Entry)
+            DispensationAllowed.isDispensationAllowed(prescription, lms02Entry)
         );
     }
 }

--- a/country-a-service/testing-shared/src/main/resources/fmk-responses/drug-medication-0410009234.xml
+++ b/country-a-service/testing-shared/src/main/resources/fmk-responses/drug-medication-0410009234.xml
@@ -487,8 +487,107 @@ Dag 21: 1 tablet</LongText>
         <ns2:SubstitutionAllowed>true</ns2:SubstitutionAllowed>
     </ns2:DrugMedication>
     <ns2:DrugMedication>
-        <ns2:Identifier>36755255</ns2:Identifier>
-        <ns2:Version>1740644244385001001</ns2:Version>
+        <ns2:Identifier>36905889</ns2:Identifier>
+        <ns2:Version>1740988220154001001</ns2:Version>
+        <ns2:Created>
+            <By>
+                <AuthorisedHealthcareProfessional>
+                    <AuthorisationIdentifier>6QF17</AuthorisationIdentifier>
+                    <Name>Charles Babbage</Name>
+                </AuthorisedHealthcareProfessional>
+                <Organisation>
+                    <Name>Gentofte Hospital, Hjertemedicinsk afdeling P</Name>
+                    <TelephoneNumber>23836750</TelephoneNumber>
+                    <Type>Sygehus</Type>
+                    <Identifier source="SKS">1501031</Identifier>
+                </Organisation>
+            </By>
+            <DateTime>2025-03-03T07:50:20Z</DateTime>
+        </ns2:Created>
+        <ns2:Modified>
+            <By>
+                <AuthorisedHealthcareProfessional>
+                    <AuthorisationIdentifier>6QF17</AuthorisationIdentifier>
+                    <Name>Charles Babbage</Name>
+                </AuthorisedHealthcareProfessional>
+                <Organisation>
+                    <Name>Gentofte Hospital, Hjertemedicinsk afdeling P</Name>
+                    <TelephoneNumber>23836750</TelephoneNumber>
+                    <Type>Sygehus</Type>
+                    <Identifier source="SKS">1501031</Identifier>
+                </Organisation>
+            </By>
+            <DateTime>2025-03-03T07:50:20Z</DateTime>
+        </ns2:Modified>
+        <ns2:Type>Lægeordineret</ns2:Type>
+        <ns2:BeginEndDate>
+            <CreatedDateTime>2025-03-03T07:50:20Z</CreatedDateTime>
+            <TreatmentStartDate>2025-03-03</TreatmentStartDate>
+            <TreatmentEndDate>2025-03-10</TreatmentEndDate>
+        </ns2:BeginEndDate>
+        <ns2:Indication>
+            <Code source="Medicinpriser" date="2025-03-03">214</Code>
+            <Text>til sårbehandling</Text>
+        </ns2:Indication>
+        <ns2:RouteOfAdministration>
+            <Code source="Medicinpriser" date="2025-03-03">KU</Code>
+            <Text>Kutan anvendelse</Text>
+        </ns2:RouteOfAdministration>
+        <ns2:Drug>
+            <ATC>
+                <Code source="Medicinpriser" date="2025-03-03">D09AB01</Code>
+                <Text>Zinkbandage uden tilsætninger</Text>
+            </ATC>
+            <Identifier source="Medicinpriser" date="2025-03-03">28101902597</Identifier>
+            <Name>Zipzoc</Name>
+            <Form>
+                <Code source="Medicinpriser" date="2025-03-03">IMPGAZE</Code>
+                <Text>imprægneret gaze</Text>
+            </Form>
+            <Substances>
+                <ActiveSubstance>
+                    <SubstanceText source="Medicinpriser" date="2025-03-03">ZINKOXID</SubstanceText>
+                </ActiveSubstance>
+            </Substances>
+        </ns2:Drug>
+        <ns2:Dosage>
+            <ns2:UnitTexts>
+                <ns2:Singular>strømpe</ns2:Singular>
+                <ns2:Plural>strømper</ns2:Plural>
+            </ns2:UnitTexts>
+            <ns2:StructuresAccordingToNeed>
+                <Structure>
+                    <IterationInterval>1</IterationInterval>
+                    <StartDate>2025-03-03</StartDate>
+                    <EndDate>2025-03-10</EndDate>
+                    <Day>
+                        <Number>1</Number>
+                        <Dose>
+                            <Quantity>1</Quantity>
+                        </Dose>
+                        <Dose>
+                            <Quantity>1</Quantity>
+                        </Dose>
+                    </Day>
+                    <DosageTranslation>
+                        <ShortText>1 strømpe efter behov, højst 2 gange daglig</ShortText>
+                        <LongText>Dosering fra d. 3. mar. 2025 til d. 10. mar. 2025:
+1 strømpe efter behov, højst 2 gange dagligt</LongText>
+                    </DosageTranslation>
+                </Structure>
+                <DosageTranslationCombined>
+                    <ShortText>1 strømpe efter behov, højst 2 gange daglig</ShortText>
+                    <LongText>Dosering fra d. 3. mar. 2025 til d. 10. mar. 2025:
+1 strømpe efter behov, højst 2 gange dagligt</LongText>
+                </DosageTranslationCombined>
+            </ns2:StructuresAccordingToNeed>
+            <ns2:Type>efter behov</ns2:Type>
+        </ns2:Dosage>
+        <ns2:SubstitutionAllowed>true</ns2:SubstitutionAllowed>
+    </ns2:DrugMedication>
+    <ns2:DrugMedication>
+        <ns2:Identifier>38974934</ns2:Identifier>
+        <ns2:Version>1744102217775001002</ns2:Version>
         <ns2:Created>
             <By>
                 <AuthorisedHealthcareProfessional>
@@ -497,12 +596,12 @@ Dag 21: 1 tablet</LongText>
                 </AuthorisedHealthcareProfessional>
                 <Organisation>
                     <Name>Udenfor organisation</Name>
-                    <TelephoneNumber>22222222</TelephoneNumber>
+                    <TelephoneNumber>87654321</TelephoneNumber>
                     <Type>Yder</Type>
                     <Identifier source="Yder">990027</Identifier>
                 </Organisation>
             </By>
-            <DateTime>2025-02-27T08:17:24Z</DateTime>
+            <DateTime>2025-04-08T08:50:17Z</DateTime>
         </ns2:Created>
         <ns2:Modified>
             <By>
@@ -512,86 +611,77 @@ Dag 21: 1 tablet</LongText>
                 </AuthorisedHealthcareProfessional>
                 <Organisation>
                     <Name>Udenfor organisation</Name>
-                    <TelephoneNumber>22222222</TelephoneNumber>
+                    <TelephoneNumber>87654321</TelephoneNumber>
                     <Type>Yder</Type>
                     <Identifier source="Yder">990027</Identifier>
                 </Organisation>
             </By>
-            <DateTime>2025-02-27T08:17:24Z</DateTime>
+            <DateTime>2025-04-08T08:50:17Z</DateTime>
         </ns2:Modified>
         <ns2:Type>Lægeordineret</ns2:Type>
         <ns2:BeginEndDate>
-            <CreatedDateTime>2025-02-27T08:17:24Z</CreatedDateTime>
-            <TreatmentStartDate>2025-02-27</TreatmentStartDate>
-            <TreatmentEndDate>2025-03-05</TreatmentEndDate>
+            <CreatedDateTime>2025-04-08T08:50:17Z</CreatedDateTime>
+            <TreatmentStartDate>2025-04-08</TreatmentStartDate>
+            <TreatmentEndingUndetermined/>
         </ns2:BeginEndDate>
         <ns2:Indication>
-            <Code source="Medicinpriser" date="2025-02-27">121</Code>
-            <Text>mod mellemørebetændelse</Text>
+            <FreeText>Mod onde onder</FreeText>
         </ns2:Indication>
         <ns2:RouteOfAdministration>
-            <Code source="Medicinpriser" date="2025-02-27">OR</Code>
-            <Text>Oral anvendelse</Text>
+            <Code source="Medicinpriser" date="2025-04-08">IK</Code>
+            <Text>Administrationsvej ikke angivet</Text>
         </ns2:RouteOfAdministration>
         <ns2:Drug>
-            <ATC>
-                <Code source="Medicinpriser" date="2025-02-27">J01CA04</Code>
-                <Text>Amoxicillin</Text>
-            </ATC>
-            <Identifier source="Medicinpriser" date="2025-02-27">28101137283</Identifier>
-            <Name>Imacillin</Name>
+            <DetailedDrugText>8 haletudser og 1 sprællende frø</DetailedDrugText>
             <Form>
-                <Code source="Medicinpriser" date="2025-02-27">ORAGRAS</Code>
-                <Text>granulat til oral suspension</Text>
+                <Code source="Medicinpriser" date="2025-04-08">BLAVSK</Code>
+                <Text>blæreskyllevæske</Text>
             </Form>
             <Strength>
-                <Value>50.0</Value>
-                <UnitCode source="Medicinpriser" date="2025-02-27">MGM</UnitCode>
-                <UnitText>mg/ml</UnitText>
-                <Text source="Medicinpriser" date="2025-02-27">50 mg/ml</Text>
+                <Value>8.0</Value>
+                <UnitCode source="Medicinpriser" date="2025-04-08">UN</UnitCode>
+                <UnitText>enheder</UnitText>
             </Strength>
             <Substances>
                 <ActiveSubstance>
-                    <SubstanceText source="Medicinpriser" date="2025-02-27">AMOXICILLINTRIHYDRAT</SubstanceText>
+                    <FreeText>Haletudse</FreeText>
+                </ActiveSubstance>
+                <ActiveSubstance>
+                    <FreeText>Frø</FreeText>
                 </ActiveSubstance>
             </Substances>
         </ns2:Drug>
         <ns2:Dosage>
             <ns2:UnitTexts>
-                <ns2:Singular>ml</ns2:Singular>
-                <ns2:Plural>ml</ns2:Plural>
+                <ns2:Singular>dråbe</ns2:Singular>
+                <ns2:Plural>dråber</ns2:Plural>
             </ns2:UnitTexts>
             <ns2:StructuresFixed>
                 <Structure>
                     <IterationInterval>1</IterationInterval>
-                    <StartDate>2025-02-27</StartDate>
-                    <EndDate>2025-03-05</EndDate>
+                    <StartDate>2025-04-08</StartDate>
+                    <EndDate>2025-04-10</EndDate>
                     <Day>
                         <Number>1</Number>
                         <Dose>
-                            <Quantity>5</Quantity>
-                        </Dose>
-                        <Dose>
-                            <Quantity>5</Quantity>
-                        </Dose>
-                        <Dose>
-                            <Quantity>5</Quantity>
+                            <Time>night</Time>
+                            <Quantity>1</Quantity>
                         </Dose>
                     </Day>
                     <DosageTranslation>
-                        <ShortText>5 ml 3 gange daglig</ShortText>
-                        <LongText>Dosering fra d. 27. feb. 2025 til d. 5. mar. 2025:
-5 ml 3 gange hver dag</LongText>
+                        <ShortText>1 dråbe nat</ShortText>
+                        <LongText>Dosering fra d. 8. apr. 2025 til d. 10. apr. 2025:
+1 dråbe hver nat</LongText>
                     </DosageTranslation>
                 </Structure>
                 <DosageTranslationCombined>
-                    <ShortText>5 ml 3 gange daglig</ShortText>
-                    <LongText>Dosering fra d. 27. feb. 2025 til d. 5. mar. 2025:
-5 ml 3 gange hver dag</LongText>
+                    <ShortText>1 dråbe nat</ShortText>
+                    <LongText>Dosering fra d. 8. apr. 2025 til d. 10. apr. 2025:
+1 dråbe hver nat</LongText>
                 </DosageTranslationCombined>
             </ns2:StructuresFixed>
             <ns2:Type>fast</ns2:Type>
         </ns2:Dosage>
-        <ns2:SubstitutionAllowed>true</ns2:SubstitutionAllowed>
+        <ns2:SubstitutionAllowed>false</ns2:SubstitutionAllowed>
     </ns2:DrugMedication>
 </ns2:GetDrugMedicationResponse>

--- a/country-a-service/testing-shared/src/main/resources/fmk-responses/get-prescription-0410009234.xml
+++ b/country-a-service/testing-shared/src/main/resources/fmk-responses/get-prescription-0410009234.xml
@@ -21,6 +21,7 @@
         <ns4:Identifier>471017992117101</ns4:Identifier>
         <ns4:AttachedToDrugMedicationIdentifier>32757830</ns4:AttachedToDrugMedicationIdentifier>
         <ns4:CreatedFromDrugMedicationVersion>1733318393043001001</ns4:CreatedFromDrugMedicationVersion>
+        <ns4:DrugMedicationEnded>Behandling afsluttet</ns4:DrugMedicationEnded>
         <ns4:AuthorisationDateTime>2024-12-04T13:19:52Z</ns4:AuthorisationDateTime>
         <ns4:Created>
             <By>
@@ -212,10 +213,72 @@
         <ns4:Version>13013</ns4:Version>
     </ns4:Prescription>
     <ns4:Prescription>
-        <ns4:Identifier>478343843634102</ns4:Identifier>
-        <ns4:AttachedToDrugMedicationIdentifier>36755255</ns4:AttachedToDrugMedicationIdentifier>
-        <ns4:CreatedFromDrugMedicationVersion>1740644244385001001</ns4:CreatedFromDrugMedicationVersion>
-        <ns4:AuthorisationDateTime>2025-02-27T08:17:24Z</ns4:AuthorisationDateTime>
+        <ns4:Identifier>478687820122101</ns4:Identifier>
+        <ns4:AttachedToDrugMedicationIdentifier>36905889</ns4:AttachedToDrugMedicationIdentifier>
+        <ns4:CreatedFromDrugMedicationVersion>1740988220154001001</ns4:CreatedFromDrugMedicationVersion>
+        <ns4:DrugMedicationEnded>Behandling afsluttet</ns4:DrugMedicationEnded>
+        <ns4:AuthorisationDateTime>2025-03-03T07:50:20Z</ns4:AuthorisationDateTime>
+        <ns4:Created>
+            <By>
+                <AuthorisedHealthcareProfessional>
+                    <AuthorisationIdentifier>6QF17</AuthorisationIdentifier>
+                    <Name>Charles Babbage</Name>
+                </AuthorisedHealthcareProfessional>
+                <Organisation>
+                    <Name>Gentofte Hospital, Hjertemedicinsk afdeling P</Name>
+                    <TelephoneNumber>23836750</TelephoneNumber>
+                    <Type>Sygehus</Type>
+                    <Identifier source="SKS">1501031</Identifier>
+                </Organisation>
+            </By>
+            <DateTime>2025-03-03T07:50:20Z</DateTime>
+        </ns4:Created>
+        <ns4:ValidFromDate>2025-03-03</ns4:ValidFromDate>
+        <ns4:ValidToDate>2025-04-09</ns4:ValidToDate>
+        <ns4:PackageRestriction>
+            <ns2:PackageNumber source="Medicinpriser" date="2025-03-03">466915</ns2:PackageNumber>
+            <ns2:PackageSize>
+                <ns2:Value>10.00</ns2:Value>
+                <ns2:UnitCode source="Medicinpriser" date="2025-03-03">ST</ns2:UnitCode>
+                <ns2:UnitText>stk.</ns2:UnitText>
+                <ns2:PackageSizeText>10 stk.</ns2:PackageSizeText>
+            </ns2:PackageSize>
+            <ns2:PackageQuantity>1</ns2:PackageQuantity>
+        </ns4:PackageRestriction>
+        <ns4:Indication>
+            <Code source="Medicinpriser" date="2025-03-03">214</Code>
+            <Text>til sårbehandling</Text>
+        </ns4:Indication>
+        <ns4:Drug>
+            <ATC>
+                <Code source="Medicinpriser" date="2025-03-03">D09AB01</Code>
+                <Text>Zinkbandage uden tilsætninger</Text>
+            </ATC>
+            <Identifier source="Medicinpriser" date="2025-03-03">28101902597</Identifier>
+            <Name>Zipzoc</Name>
+            <Form>
+                <Code source="Medicinpriser" date="2025-03-03">IMPGAZE</Code>
+                <Text>imprægneret gaze</Text>
+            </Form>
+            <Strength>
+                <Text source="Medicinpriser" date="2025-03-03">Ukendt</Text>
+            </Strength>
+            <Substances>
+                <ActiveSubstance>
+                    <SubstanceText source="Medicinpriser" date="2025-03-03">ZINKOXID</SubstanceText>
+                </ActiveSubstance>
+            </Substances>
+        </ns4:Drug>
+        <ns4:DosageText>1 strømpe efter behov, højst 2 gange daglig</ns4:DosageText>
+        <ns4:SubstitutionAllowed>true</ns4:SubstitutionAllowed>
+        <ns4:Status>åben</ns4:Status>
+        <ns4:Version>26820</ns4:Version>
+    </ns4:Prescription>
+    <ns4:Prescription>
+        <ns4:Identifier>481801817572102</ns4:Identifier>
+        <ns4:AttachedToDrugMedicationIdentifier>38974934</ns4:AttachedToDrugMedicationIdentifier>
+        <ns4:CreatedFromDrugMedicationVersion>1744102217775001002</ns4:CreatedFromDrugMedicationVersion>
+        <ns4:AuthorisationDateTime>2025-04-08T08:50:17Z</ns4:AuthorisationDateTime>
         <ns4:Created>
             <By>
                 <AuthorisedHealthcareProfessional>
@@ -224,55 +287,49 @@
                 </AuthorisedHealthcareProfessional>
                 <Organisation>
                     <Name>Udenfor organisation</Name>
-                    <TelephoneNumber>22222222</TelephoneNumber>
+                    <TelephoneNumber>87654321</TelephoneNumber>
                     <Type>Yder</Type>
                     <Identifier source="Yder">990027</Identifier>
                 </Organisation>
             </By>
-            <DateTime>2025-02-27T08:17:24Z</DateTime>
+            <DateTime>2025-04-08T08:50:17Z</DateTime>
         </ns4:Created>
-        <ns4:ValidFromDate>2025-02-27</ns4:ValidFromDate>
-        <ns4:ValidToDate>2025-04-04</ns4:ValidToDate>
+        <ns4:ValidFromDate>2025-04-08</ns4:ValidFromDate>
+        <ns4:ValidToDate>2027-04-08</ns4:ValidToDate>
         <ns4:PackageRestriction>
-            <ns2:PackageNumber source="Medicinpriser" date="2025-02-27">79442</ns2:PackageNumber>
+            <ns2:PackageNumber source="Local" date="2025-04-08">922222</ns2:PackageNumber>
             <ns2:PackageSize>
-                <ns2:Value>100.00</ns2:Value>
-                <ns2:UnitCode source="Medicinpriser" date="2025-02-27">ML</ns2:UnitCode>
-                <ns2:UnitText>ml</ns2:UnitText>
-                <ns2:PackageSizeText>100 ml</ns2:PackageSizeText>
+                <ns2:PackageSizeText>6</ns2:PackageSizeText>
             </ns2:PackageSize>
             <ns2:PackageQuantity>1</ns2:PackageQuantity>
         </ns4:PackageRestriction>
         <ns4:Indication>
-            <Code source="Medicinpriser" date="2025-02-27">121</Code>
-            <Text>mod mellemørebetændelse</Text>
+            <FreeText>Mod onde onder</FreeText>
         </ns4:Indication>
         <ns4:Drug>
-            <ATC>
-                <Code source="Medicinpriser" date="2025-02-27">J01CA04</Code>
-                <Text>Amoxicillin</Text>
-            </ATC>
-            <Identifier source="Medicinpriser" date="2025-02-27">28101137283</Identifier>
-            <Name>Imacillin</Name>
+            <DetailedDrugText>8 haletudser og 1 sprællende frø</DetailedDrugText>
             <Form>
-                <Code source="Medicinpriser" date="2025-02-27">ORAGRAS</Code>
-                <Text>granulat til oral suspension</Text>
+                <Code source="Medicinpriser" date="2025-04-08">BLAVSK</Code>
+                <Text>blæreskyllevæske</Text>
             </Form>
             <Strength>
-                <Value>50.0</Value>
-                <UnitCode source="Medicinpriser" date="2025-02-27">MGM</UnitCode>
-                <UnitText>mg/ml</UnitText>
-                <Text source="Medicinpriser" date="2025-02-27">50 mg/ml</Text>
+                <Value>8.0</Value>
+                <UnitCode source="Medicinpriser" date="2025-04-08">UN</UnitCode>
+                <UnitText>enheder</UnitText>
+                <Text source="Medicinpriser" date="2025-04-08">8 enheder</Text>
             </Strength>
             <Substances>
                 <ActiveSubstance>
-                    <SubstanceText source="Medicinpriser" date="2025-02-27">AMOXICILLINTRIHYDRAT</SubstanceText>
+                    <FreeText>Haletudse</FreeText>
+                </ActiveSubstance>
+                <ActiveSubstance>
+                    <FreeText>Frø</FreeText>
                 </ActiveSubstance>
             </Substances>
         </ns4:Drug>
-        <ns4:DosageText>5 ml 3 gange daglig</ns4:DosageText>
-        <ns4:SubstitutionAllowed>true</ns4:SubstitutionAllowed>
+        <ns4:DosageText>1 dråbe nat</ns4:DosageText>
+        <ns4:SubstitutionAllowed>false</ns4:SubstitutionAllowed>
         <ns4:Status>åben</ns4:Status>
-        <ns4:Version>4594</ns4:Version>
+        <ns4:Version>17841</ns4:Version>
     </ns4:Prescription>
 </ns4:GetPrescriptionResponse>


### PR DESCRIPTION
We check for `DetailedDrugText`. This because this element is only there
for magistral drugs, never for other drugs, and it's the only element
that distinguishes magistral drugs.