### PR TITLE
eP CDA updates

### DIFF
--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL1Mapper.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL1Mapper.java
@@ -15,11 +15,9 @@ public final class EPrescriptionL1Mapper {
     }
 
     public static EPrescriptionL1 model(EPrescriptionL3 l3Model) throws MapperException {
-        var modelWithL1Id = l3Model.toBuilder()
-            .documentId(new CdaId(
-                Oid.DK_EPRESCRIPTION_REPOSITORY_ID, EPrescriptionDocumentIdMapper.level1DocumentId(l3Model.getPrescriptionId()
-                .getExtension())))
-            .build();
+        var modelWithL1Id = l3Model.withDocumentId(new CdaId(
+            Oid.DK_EPRESCRIPTION_REPOSITORY_ID,
+            EPrescriptionDocumentIdMapper.level1DocumentId(l3Model.getPrescriptionId().getExtension())));
         var pdfModel = EPrescriptionPdfMapper.map(modelWithL1Id);
         var pdf = EPrescriptionPdfGenerator.generate(pdfModel);
         var base64Pdf = Base64.getEncoder().encodeToString(pdf);

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
@@ -368,7 +368,6 @@ public class EPrescriptionL3Mapper {
 
     private static String getSubstanceStrengthText(DrugStrengthType strength) {
         if (strength == null) return null;
-        if (strength.getUnitText() != null) return strength.getUnitText();
         if (strength.getText() != null) return strength.getText().getValue();
         return null;
     }

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionPdfMapper.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionPdfMapper.java
@@ -69,7 +69,7 @@ public class EPrescriptionPdfMapper {
         lines.add(String.format(
             "%s %s (%s)",
             model.getProduct().getName(),
-            model.getProduct().getDescription(),
+            model.getProduct().getStrength(),
             model.getProduct().getAtcCode().getDisplayName()));
         lines.add(packageLine(model));
         lines.add("");

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/EPrescriptionL3.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/EPrescriptionL3.java
@@ -54,8 +54,8 @@ public class EPrescriptionL3 {
 
     /// List of active ingredients, if we have them structured.
     @NonNull List<ActiveIngredient> activeIngredients;
-    /// The text of the active ingredients if we don't have them structured.
-    String unstructuredActiveIngredients;
+    /// The unstructured text of the active ingredients.
+    @NonNull String unstructuredActiveIngredients;
 
     @NonNull Author author;
 

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/EPrescriptionL3.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/EPrescriptionL3.java
@@ -4,12 +4,14 @@ import dk.sundhedsdatastyrelsen.ncpeh.cda.Utils;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
+import lombok.With;
 
 import java.time.OffsetDateTime;
 import java.util.List;
 
 @Value
-@Builder(toBuilder = true)
+@Builder
+@With
 public class EPrescriptionL3 {
     /**
      * Unique ID identifying the CDA document (not the prescription itself).

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Product.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Product.java
@@ -3,24 +3,21 @@ package dk.sundhedsdatastyrelsen.ncpeh.cda.model;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
+import lombok.With;
 
 @Value
 @Builder
+@With
 public class Product {
     /// LMS drug id
     CdaCode drugId;
     @NonNull String name;
     String strength;
-    String description;
+    @NonNull String description;
     @NonNull CdaCode formCode;
     CdaCode packageCode;
     CdaCode packageFormCode;
     @NonNull CdaCode atcCode;
     @NonNull Size size;
     String manufacturerOrganizationName;
-
-    public String getDescription(){ //Right now, description just returns the strength
-        return getStrength();
-    }
-
 }

--- a/country-a-service/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
+++ b/country-a-service/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
@@ -140,7 +140,7 @@
                             ${ product.name }
                             ${ indicationText }
                             ${ patientMedicationInstructions }
-                            <#if unstructuredActiveIngredients??>${ unstructuredActiveIngredients }</#if>
+                            ${ unstructuredActiveIngredients }
 
                             ${ dosage.unstructuredText }
                         </content>

--- a/country-a-service/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
+++ b/country-a-service/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
@@ -142,8 +142,6 @@
                             ${ patientMedicationInstructions }
                             <#if unstructuredActiveIngredients??>${ unstructuredActiveIngredients }</#if>
 
-                            Unstructured dosage text:
-
                             ${ dosage.unstructuredText }
                         </content>
                         <content ID="product-name">${ product.name }</content>

--- a/country-a-service/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
+++ b/country-a-service/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
@@ -212,8 +212,9 @@
                                         <code <@common.cdaCodeAttrs product.drugId />/>
 </#if>
                                         <name>${ product.name }</name>
-<#if product.description??>
-                                        <pharm:desc>${ product.description }</pharm:desc>
+<#if product.strength??>
+                                        <#-- "Free-text representation of the strength." -->
+                                        <pharm:desc>${ product.strength }</pharm:desc>
 </#if>
                                         <pharm:formCode <@common.cdaCodeAttrs product.formCode />/>
                                         <pharm:asContent classCode="CONT">
@@ -230,7 +231,12 @@
 </#if>
                                             <pharm:containerPackagedProduct classCode="CONT" determinerCode="KIND">
                                                 <pharm:code <@common.cdaCodeAttrs product.packageCode/> />
-                                                <pharm:name>${ product.name }</pharm:name>
+                                                <#-- "If present, the element SHALL contain a sufficiently detailed description of
+                                                the prescribed medicinal product/package. The description may contain information
+                                                on the brand name, dose form, package (including its type or brand name), strength, etc.
+
+                                                If the detailed description of the product is not available, the element SHALL be skipped." -->
+                                                <pharm:name>${ product.description }</pharm:name>
 <#if (product.packageFormCode.code)?has_content>
                                                 <pharm:formCode <@common.cdaCodeAttrs product.packageFormCode/> />
 <#else>

--- a/country-a-service/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3GeneratorTest.java
+++ b/country-a-service/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3GeneratorTest.java
@@ -1,7 +1,6 @@
 package dk.sundhedsdatastyrelsen.ncpeh.cda;
 
 import dk.nsi._2024._01._05.stamdataauthorization.AuthorizationType;
-import dk.sundhedsdatastyrelsen.ncpeh.cda.model.Product;
 import dk.sundhedsdatastyrelsen.ncpeh.testing.shared.FmkResponseStorage;
 import freemarker.template.TemplateException;
 import org.junit.jupiter.api.Assertions;
@@ -41,16 +40,8 @@ class EPrescriptionL3GeneratorTest {
         Assertions.assertFalse(xmlString.isBlank());
 
         //Set packageCode to null, and regenerate
-        var productWithNullPackageCode = Product.builder()
-            .packageCode(epL3.getProduct().getPackageCode())
-            .packageFormCode(null)
-            .atcCode(epL3.getProduct().getAtcCode())
-            .formCode(epL3.getProduct().getFormCode())
-            .strength(epL3.getProduct().getStrength())
-            .name(epL3.getProduct().getName())
-            .size(epL3.getProduct().getSize())
-            .build();
-        var epL3NullPackageCode = epL3.toBuilder().product(productWithNullPackageCode).build();
+        var productWithNullPackageCode = epL3.getProduct().withPackageFormCode(null);
+        var epL3NullPackageCode = epL3.withProduct(productWithNullPackageCode);
         var xmlStringWithNullPackageCode = EPrescriptionL3Generator.generate(epL3NullPackageCode);
         Assertions.assertNotNull(xmlStringWithNullPackageCode);
         Assertions.assertFalse(xmlStringWithNullPackageCode.isBlank());


### PR DESCRIPTION
- Put a description of the drug/packaging into `pharm:name` (#220)
- Remove "Unstructured..." header from entry text
- Always show unstructured dosage info, also when we have structured.
- Fix bug where only strength unit, not value, was displayed in unstructured dosage information