### PR TITLE
141 dosage logging and time zones

### DIFF
--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Generator.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Generator.java
@@ -7,6 +7,9 @@ import java.io.IOException;
 import java.io.StringWriter;
 
 public class EPrescriptionL3Generator {
+    private EPrescriptionL3Generator() {
+    }
+
     public static String generate(EPrescriptionL3 dataModel) throws IOException, TemplateException {
         var template = FreemarkerConfiguration.config().getTemplate("eprescription-cda-l3.ftlx");
         var writer = new StringWriter();

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
@@ -28,6 +28,7 @@ import dk.sundhedsdatastyrelsen.ncpeh.cda.model.Patient;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.Product;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.Size;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.nio.charset.StandardCharsets;
@@ -43,6 +44,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Slf4j
 public class EPrescriptionL3Mapper {
     private EPrescriptionL3Mapper() {
     }
@@ -90,6 +92,10 @@ public class EPrescriptionL3Mapper {
 
         if (medication.isPresent()) {
             var drugMedicationType = medication.get();
+            var dosage = DosageMapper.model(drugMedicationType.getDosage());
+            if (dosage instanceof Dosage.Unstructured unstructured) {
+                log.info("Dosage could not be mapped. Reason: {}", unstructured.getReason());
+            }
             prescriptionBuilder
                 .medicationStartTime(Utils.convertToOffsetDateTime(drugMedicationType.getBeginEndDate()
                     .getTreatmentStartDate()))

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/Utils.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/Utils.java
@@ -11,15 +11,15 @@ public final class Utils {
     private Utils() {
     }
 
-    static final DateTimeFormatter cdaDateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssZ", Locale.ROOT);
+    static final DateTimeFormatter cdaZonedDateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssZ", Locale.ROOT);
     static final DateTimeFormatter cdaDateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd", Locale.ROOT);
-    static final DateTimeFormatter cdaTSFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+    static final DateTimeFormatter cdaLocalDateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
 
     /**
      * Convert java.time value to "TS Time Stamp" datetime string as expected by CDA.
      */
-    public static String cdaDateTime(TemporalAccessor time) {
-        return cdaDateTimeFormatter.format(time);
+    public static String cdaZonedDateTime(TemporalAccessor time) {
+        return cdaZonedDateTimeFormatter.format(time);
     }
 
     /**
@@ -29,8 +29,8 @@ public final class Utils {
         return cdaDateFormatter.format(time);
     }
 
-    public static String cdaTs(TemporalAccessor time) {
-        return cdaTSFormatter.format(time);
+    public static String cdaLocalDateTime(TemporalAccessor time) {
+        return cdaLocalDateTimeFormatter.format(time);
     }
 
     /**

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Author.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Author.java
@@ -23,6 +23,6 @@ public class Author {
     @NonNull Organization organization;
 
     public String getTime() {
-        return Utils.cdaDateTime(time);
+        return Utils.cdaZonedDateTime(time);
     }
 }

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Dosage.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Dosage.java
@@ -9,7 +9,7 @@ import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.time.LocalDate;
-import java.time.ZonedDateTime;
+import java.time.LocalDateTime;
 import java.util.Locale;
 
 public sealed interface Dosage {
@@ -68,13 +68,13 @@ public sealed interface Dosage {
     class Once implements Dosage {
         String tag = "Once";
         @NonNull String unstructuredText;
-        @NonNull Either<LocalDate, ZonedDateTime> timeValue;
+        @NonNull Either<LocalDate, LocalDateTime> timeValue;
         Quantity quantity;
 
         public String getTimeValue() {
-            // TODO unsure about the formatting of the ZonedDateTime value. In art-decor, it's specified as `CCYYMMDDHHMMSS`,
-            //  but elsewhere we use the offset version.
-            return timeValue.match(Utils::cdaDate, Utils::cdaTs);
+            // Dosage times are always local. It is up to the health professional dispensing the medicine to consider
+            // changing time zones.
+            return timeValue.match(Utils::cdaDate, Utils::cdaLocalDateTime);
         }
     }
 

--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/EPrescriptionL3.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/EPrescriptionL3.java
@@ -79,7 +79,7 @@ public class EPrescriptionL3 {
     @NonNull String patientMedicationInstructions;
 
     public String getEffectiveTime() {
-        return Utils.cdaDateTime(effectiveTime);
+        return Utils.cdaZonedDateTime(effectiveTime);
     }
 
     public OffsetDateTime getEffectiveTimeOffsetDateTime() {
@@ -87,7 +87,7 @@ public class EPrescriptionL3 {
     }
 
     public String getSignatureTime() {
-        return Utils.cdaDateTime(signatureTime);
+        return Utils.cdaZonedDateTime(signatureTime);
     }
 
     public String getPackageQuantity() {


### PR DESCRIPTION
141: dosage times are always local

It is up to the health professional dispensing the medicine to consider
whether anything has to be done when changing time zones.

141: enable logging of unstructured dosage reasons

Closes #141 