### PR TITLE
Change country-a default TLS port to 4443

### DIFF
--- a/NCP/docker-compose.yml
+++ b/NCP/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       - ./heapdumps/tomcat_node_a:/heapdumps
     environment:
       # JAVA_TOOL_OPTIONS: "-agentlib:jdwp=transport=dt_socket,address=*:5005,server=y,suspend=n"
-      NC_DK_COUNTRY_A_HOST: "https://epps-country-a:8443"
+      NC_DK_COUNTRY_A_HOST: "https://epps-country-a:4443"
       JAVA_OPTS: "
         -Dlogging.config=/opt/logging/logback.xml
         -DopenATNA.properties.path=file:/opt/atna-resources/openatna.properties

--- a/country-a-service/config/application.yml
+++ b/country-a-service/config/application.yml
@@ -10,7 +10,7 @@ spring:
     locations: "classpath:db/migration"
 
 server:
-  port: 8443
+  port: 4443
   ssl:
     key-store: ${COUNTRY_A_KEYSTORE_LOCATION}
     key-store-password: ${COUNTRY_A_KEYSTORE_PASSWORD}


### PR DESCRIPTION
To prevent confusion, especially with local development, I've moved the default country-a-service TLS port to 4443.  Port 8443 was already taken as the default port for the NCP-A service.

Now, it's possible to run both OpenNCP and country-a-service on the same machine.