### PR TITLE
Disable failing end-to-end test

### DIFF
--- a/country-a-service/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/End2EndIT.java
+++ b/country-a-service/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/End2EndIT.java
@@ -10,6 +10,7 @@ import dk.sundhedsdatastyrelsen.ncpeh.script.FmkPrescriptionCreator;
 import dk.sundhedsdatastyrelsen.ncpeh.testing.shared.Fmk;
 import jakarta.xml.bind.JAXBException;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -35,6 +36,7 @@ class End2EndIT {
 
     /// See the resources/portal-backend-examples folder for examples of the requests and responses.
     @Test
+    @Disabled("HBG 2025-07-07: Fails every night. Fix test before re-enabling.")
     void fetchAndDispenseThroughCountryB() throws Exception {
         // Setup
         assertThat(String.format("Missing environment variable \"%s\"", HOST_ENV_NAME), HOST, is(not(nullValue())));


### PR DESCRIPTION
The End2EndIT test makes the nightly pipeline fail every night.

I disable it for now until we fix the test, to avoid "failing pipeline fatigue".