### PR TITLE
change nightly test run time to 04:30 UTC

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,7 @@ name: Nightly integration test
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 01 * * *"
+    - cron: "30 04 * * *"
 
 jobs:
   integration-tests:


### PR DESCRIPTION
This because we currently fail almost every Friday and Sunday. We assume we're hitting maintenance windows from our dependencies.