### PR TITLE
Make AuthorizationService WSDL available offline

### DIFF
--- a/country-a-service/epps-api/autorisationsregister-model/src/main/resources/AuthorizationService-20240105.wsdl
+++ b/country-a-service/epps-api/autorisationsregister-model/src/main/resources/AuthorizationService-20240105.wsdl
@@ -67,10 +67,10 @@
 
     <!-- Den gode webservice schemas. -->
     <xsd:schema targetNamespace="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
-    <xsd:include schemaLocation="http://test1-cnsp.ekstern-test.nspop.dk:8080/stamdata-authorization-lookup-ws/service/AuthorizationService-20240105?xsd=4"/>
+    <xsd:include schemaLocation="./xsd/4"/>
   </xsd:schema>
   <xsd:schema targetNamespace="http://www.medcom.dk/dgws/2006/04/dgws-1.0.xsd">
-    <xsd:include schemaLocation="http://test1-cnsp.ekstern-test.nspop.dk:8080/stamdata-authorization-lookup-ws/service/AuthorizationService-20240105?xsd=2"/>
+    <xsd:include schemaLocation="./xsd/2"/>
   </xsd:schema>
   
     <!-- NB: This is added to avoid JAX-WS mapping date to XMLGregorialCalendar, which does not play nice with SEAL. -->

--- a/country-a-service/epps-api/autorisationsregister-model/src/main/resources/fetch_wsdl.clj
+++ b/country-a-service/epps-api/autorisationsregister-model/src/main/resources/fetch_wsdl.clj
@@ -1,0 +1,85 @@
+#!/usr/bin/env bb
+
+;;; Fetch WSDL and XSD dependencies.
+;;; Run with Babashka: https://github.com/babashka/babashka#installation
+
+(ns fetch-wsdl
+  (:require
+   [babashka.fs :as fs]
+   [babashka.http-client :as http]
+   [clojure.string :as str]
+   [clojure.java.io :as io])
+  (:import
+   (java.net URI)))
+
+(defn extract-filename [url]
+  (if (str/includes? url "?xsd=")
+    ;; Extract filename from ?xsd= parameter
+    (second (re-matches #".*\?xsd=([^&]*).*" url))
+    ;; Extract filename from URL path, removing query parameters
+    (first (str/split (last (str/split url #"/")) #"\?"))))
+
+(defn non-empty? [file-path]
+  (and (fs/exists? file-path)
+       (pos? (fs/size file-path))))
+
+(defn download-file [url file-path]
+  (println (str "Fetching " url " -> " file-path))
+  (io/copy
+   (:body (http/get url {:as :stream}))
+   (fs/file file-path)))
+
+(defn extract-schema-locations [file-path]
+  (->> (re-seq #"schemaLocation=\"([^\"]*)\"" (slurp file-path))
+       (map second)))
+
+(defn uri [p] (if (instance? URI p) p (URI. p)))
+
+(defn fetch-files [urls base-url]
+  (let [fetch-file
+        (fn [url]
+          (let [file-path (str "xsd/" (extract-filename url))]
+            (if (non-empty? file-path)
+              (println "File exists, skipping:" file-path)
+              (let [resolved-url (.resolve (uri base-url) url)]
+                (download-file resolved-url file-path)
+                (fetch-files (extract-schema-locations file-path) resolved-url)))))]
+    (doall (pmap fetch-file urls))))
+
+(defn fix-schema-locations [file substituent-prefix]
+  (let [new-content
+        (-> (slurp file)
+            ;; Fix schemaLocation in xsds
+            (str/replace #"schemaLocation=\"[^\"]*/([^\"]+)\""
+                         (str "schemaLocation=\"" substituent-prefix "$1\""))
+            ;; Handle ?xsd= parameters in schemaLocation
+            (str/replace #"schemaLocation=\"[^\"]*\?xsd=([^\"]+)\""
+                         (str "schemaLocation=\"" substituent-prefix "$1\"")))]
+    (spit file new-content)))
+
+(defn fetch-wsdl [wsdl-url wsdl-local-path]
+  (println "Processing WSDL...")
+
+  (or (non-empty? wsdl-local-path)
+      (download-file wsdl-url wsdl-local-path))
+
+  ;; Create xsd directory if it doesn't exist
+  (fs/create-dirs "xsd")
+
+  ;; Fetch schema files
+  (fetch-files (extract-schema-locations wsdl-local-path) wsdl-url)
+
+  ;; Fix schema locations
+  (fix-schema-locations wsdl-local-path "./xsd/")
+
+  ;; Fix schema locations in XSD files
+  (->> (fs/list-dir "xsd")
+       (filter fs/regular-file?)
+       (map fs/file)
+       (run! #(fix-schema-locations % "./"))))
+
+(def wsdl-url
+  "http://test1-cnsp.ekstern-test.nspop.dk:8080/stamdata-authorization-lookup-ws/service/AuthorizationService-20240105?wsdl")
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (fetch-wsdl wsdl-url "AuthorizationService-20240105.wsdl"))

--- a/country-a-service/epps-api/autorisationsregister-model/src/main/resources/xsd/1
+++ b/country-a-service/epps-api/autorisationsregister-model/src/main/resources/xsd/1
@@ -1,0 +1,98 @@
+<?xml version='1.0' encoding='UTF-8'?><!-- Published by JAX-WS RI at http://jax-ws.dev.java.net. RI's version is JAX-WS RI 2.1.7-b01-. --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.w3.org/2000/09/xmldsig#" elementFormDefault="qualified">
+	<xs:element name="Signature">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ds:SignedInfo"/>
+				<xs:element ref="ds:SignatureValue"/>
+				<xs:element ref="ds:KeyInfo"/>
+			</xs:sequence>
+			<xs:attribute name="id" type="xs:NCName" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="SignedInfo">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ds:CanonicalizationMethod"/>
+				<xs:element ref="ds:SignatureMethod"/>
+				<xs:element ref="ds:Reference" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="CanonicalizationMethod">
+		<xs:complexType>
+			<xs:attribute name="Algorithm" use="required">
+				<xs:simpleType>
+					<xs:restriction base="xs:anyURI">
+						<xs:enumeration value="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+						<xs:enumeration value="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="SignatureMethod">
+		<xs:complexType>
+			<xs:attribute name="Algorithm" use="required">
+				<xs:simpleType>
+					<xs:restriction base="xs:anyURI">
+						<xs:enumeration value="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Reference">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ds:Transforms" minOccurs="0"/>
+				<xs:element ref="ds:DigestMethod"/>
+				<xs:element ref="ds:DigestValue"/>
+			</xs:sequence>
+			<xs:attribute name="URI" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Transforms">
+		<xs:complexType>
+			<xs:sequence maxOccurs="unbounded">
+				<xs:element name="Transform">
+					<xs:complexType>
+						<xs:attribute name="Algorithm" use="required"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="DigestMethod">
+		<xs:complexType>
+			<xs:attribute name="Algorithm" use="required">
+				<xs:simpleType>
+					<xs:restriction base="xs:anyURI">
+						<xs:enumeration value="http://www.w3.org/2000/09/xmldsig#sha1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="DigestValue" type="xs:base64Binary"/>
+	<xs:element name="SignatureValue" type="xs:base64Binary"/>
+	<xs:element name="KeyInfo">
+		<xs:complexType>
+			<xs:choice>
+				<xs:element ref="ds:KeyName"/>
+				<xs:sequence>
+					<xs:element ref="ds:X509Data"/>
+				</xs:sequence>
+			</xs:choice>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="KeyName" type="xs:NMTOKEN"/>
+	<xs:element name="X509Data">
+		<xs:complexType>
+			<xs:choice>
+				<xs:element ref="ds:X509Certificate"/>
+				<xs:element ref="ds:KeyName"/>
+			</xs:choice>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="X509Certificate" type="xs:base64Binary"/>
+</xs:schema>

--- a/country-a-service/epps-api/autorisationsregister-model/src/main/resources/xsd/2
+++ b/country-a-service/epps-api/autorisationsregister-model/src/main/resources/xsd/2
@@ -1,0 +1,89 @@
+<?xml version='1.0' encoding='UTF-8'?><!-- Published by JAX-WS RI at http://jax-ws.dev.java.net. RI's version is JAX-WS RI 2.1.7-b01-. --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:medcom="http://www.medcom.dk/dgws/2006/04/dgws-1.0.xsd" elementFormDefault="qualified" targetNamespace="http://www.medcom.dk/dgws/2006/04/dgws-1.0.xsd">
+  <xs:element name="Linking">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="medcom:FlowID" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="medcom:MessageID" minOccurs="1" maxOccurs="1"/>
+        <xs:element ref="medcom:InResponseToMessageID" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="FlowID" type="xs:string"/>
+  <xs:element name="MessageID" type="xs:string"/>
+  <xs:element name="InResponseToMessageID" type="xs:string"/>
+  <xs:element name="Priority">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="AKUT"/>
+        <xs:enumeration value="HASTER"/>
+        <xs:enumeration value="RUTINE"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+  <xs:element name="RequireNonRepudiationReceipt">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="yes"/>
+        <xs:enumeration value="no"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+  <xs:element name="FlowStatus">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="flow_running"/>
+        <xs:enumeration value="flow_finalized_succesfully"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+  <xs:element name="SecurityLevel">
+    <xs:simpleType>
+      <xs:restriction base="xs:int">
+        <xs:enumeration value="1"/>
+        <xs:enumeration value="2"/>
+        <xs:enumeration value="3"/>
+        <xs:enumeration value="4"/>
+        <xs:enumeration value="5"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+  <xs:element name="TimeOut">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="5"/>
+        <xs:enumeration value="30"/>
+        <xs:enumeration value="480"/>
+        <xs:enumeration value="1440"/>
+        <xs:enumeration value="unbound"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+  <xs:element name="Header">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="medcom:SecurityLevel" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="medcom:TimeOut" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="medcom:Linking" minOccurs="1" maxOccurs="1"/>
+        <xs:element ref="medcom:FlowStatus" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="medcom:Priority" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="medcom:RequireNonRepudiationReceipt" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+      <!-- Added by SEAL -->
+	  <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="FaultCode">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="sosigw_no_valid_idcard_in_request"/>
+        <xs:enumeration value="sosigw_missing_signinginfo_in_request"/>
+        <xs:enumeration value="sosigw_syntax_error_in_request"/>
+        <xs:enumeration value="sosigw_awaiting_signing"/>
+        <xs:enumeration value="sosigw_no_valid_idcard_in_cache"/>
+        <xs:enumeration value="sosigw_access_denied"/>
+        <xs:enumeration value="sosigw_internal_error"/>
+        <xs:enumeration value="sosigw_proxy_error"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>

--- a/country-a-service/epps-api/autorisationsregister-model/src/main/resources/xsd/3
+++ b/country-a-service/epps-api/autorisationsregister-model/src/main/resources/xsd/3
@@ -1,0 +1,125 @@
+<?xml version='1.0' encoding='UTF-8'?><!-- Published by JAX-WS RI at http://jax-ws.dev.java.net. RI's version is JAX-WS RI 2.1.7-b01-. --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="urn:oasis:names:tc:SAML:2.0:assertion" elementFormDefault="qualified">
+	<xs:import namespace="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" schemaLocation="./4"/>
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="./1"/>
+    <xs:element name="Assertion" type="saml:AssertionType"/>
+    <xs:complexType name="AssertionType">
+        <xs:sequence>
+            <xs:element ref="saml:Issuer"/>
+            <xs:element ref="saml:Subject"/>
+            <xs:element ref="saml:Conditions"/>
+            <xs:element ref="saml:AttributeStatement" maxOccurs="3"/>
+            <xs:element ref="ds:Signature" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="IssueInstant" type="xs:dateTime" use="required"/>
+        <xs:attribute name="Version" type="xs:decimal" use="required"/>
+        <xs:attribute name="id" type="xs:NCName" use="required"/>
+    </xs:complexType>
+
+	<xs:element name="Issuer" type="xs:NCName"/>
+	<xs:element name="Subject">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="saml:NameID"/>
+				<xs:element ref="saml:SubjectConfirmation" minOccurs="0"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:element name="NameID" type="saml:NameIDType"/>
+	<xs:complexType name="NameIDType">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="Format" type="saml:SubjectIdentifierType" use="required"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:element name="SubjectConfirmation">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="saml:ConfirmationMethod"/>
+				<xs:element ref="saml:SubjectConfirmationData"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="ConfirmationMethod">
+		<xs:simpleType>
+			<xs:restriction base="xs:anyURI">
+				<xs:enumeration value="urn:oasis:names:tc:SAML:2.0:cm:holder-of-key"/>
+			</xs:restriction>
+		</xs:simpleType>
+	</xs:element>
+	<xs:element name="SubjectConfirmationData">
+		<xs:complexType>
+			<xs:choice>
+				<xs:element ref="ds:KeyInfo"/>
+				<xs:element ref="wsse:UsernameToken"/>
+			</xs:choice>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Conditions">
+		<xs:complexType>
+			<xs:attribute name="NotBefore" type="xs:dateTime" use="required"/>
+			<xs:attribute name="NotOnOrAfter" type="xs:dateTime" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AttributeStatement">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="saml:Attribute" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:attribute name="id" use="required">
+				<xs:simpleType>
+					<xs:restriction base="xs:NCName">
+						<xs:enumeration value="IDCardData"/>
+						<xs:enumeration value="UserLog"/>
+						<xs:enumeration value="SystemLog"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Attribute">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="saml:AttributeValue"/>
+			</xs:sequence>
+			<xs:attribute name="Name" use="required">
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="sosi:IDCardID"/>
+						<xs:enumeration value="sosi:IDCardVersion"/>
+						<xs:enumeration value="sosi:IDCardType"/>
+						<xs:enumeration value="sosi:AuthenticationLevel"/>
+						<xs:enumeration value="sosi:OCESCertHash"/>
+						<xs:enumeration value="medcom:UserCivilRegistrationNumber"/>
+						<xs:enumeration value="medcom:UserGivenName"/>
+						<xs:enumeration value="medcom:UserSurName"/>
+						<xs:enumeration value="medcom:UserEmailAddress"/>
+						<xs:enumeration value="medcom:UserRole"/>
+						<xs:enumeration value="medcom:UserOccupation"/>
+						<xs:enumeration value="medcom:UserAuthorizationCode"/>
+						<xs:enumeration value="medcom:CareProviderID"/>
+						<xs:enumeration value="medcom:CareProviderName"/>
+						<xs:enumeration value="medcom:ITSystemName"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="NameFormat" type="saml:SubjectIdentifierType"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AttributeValue" type="xs:string"/>
+	<xs:simpleType name="SubjectIdentifierType">
+		<xs:restriction base="xs:anyURI">
+			<xs:enumeration value="medcom:cprnumber"/>
+			<xs:enumeration value="medcom:ynumber"/>
+			<xs:enumeration value="medcom:pnumber"/>
+			<xs:enumeration value="medcom:skscode"/>
+			<xs:enumeration value="medcom:cvrnumber"/>
+			<xs:enumeration value="medcom:communalnumber"/>
+			<xs:enumeration value="medcom:locationnumber"/>
+			<xs:enumeration value="medcom:itsystemname"/>
+			<xs:enumeration value="medcom:other"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/country-a-service/epps-api/autorisationsregister-model/src/main/resources/xsd/4
+++ b/country-a-service/epps-api/autorisationsregister-model/src/main/resources/xsd/4
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?><!-- Published by JAX-WS RI at http://jax-ws.dev.java.net. RI's version is JAX-WS RI 2.1.7-b01-. --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" elementFormDefault="qualified" targetNamespace="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+  <xs:import namespace="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" schemaLocation="./5"/>
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="./1"/>
+  <xs:import namespace="urn:oasis:names:tc:SAML:2.0:assertion" schemaLocation="./3"/>
+  <xs:element name="Security">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="wsu:Timestamp" minOccurs="1" maxOccurs="1"/>
+        <xs:element ref="saml:Assertion" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="ds:Signature" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="UsernameToken">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="wsse:Username" minOccurs="1" maxOccurs="1"/>
+        <xs:element ref="wsse:Password" minOccurs="1" maxOccurs="1"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Username" type="xs:NCName"/>
+  <xs:element name="Password" type="xs:NCName"/>
+</xs:schema>

--- a/country-a-service/epps-api/autorisationsregister-model/src/main/resources/xsd/5
+++ b/country-a-service/epps-api/autorisationsregister-model/src/main/resources/xsd/5
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?><!-- Published by JAX-WS RI at http://jax-ws.dev.java.net. RI's version is JAX-WS RI 2.1.7-b01-. --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" targetNamespace="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" elementFormDefault="qualified">
+	<xs:element name="Timestamp">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="wsu:Created"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Created" type="xs:dateTime"/>
+</xs:schema>


### PR DESCRIPTION
The AuthorizationService WSDL has been sporadically available lately.  We download it and check it in so we can still compile.

Does not address #279, but uses exactly the same script as minlog. So we have some more evidence that this approach is sound.