### PR TITLE
add required properties to app properties

### DIFF
--- a/country-a-service/config/application.yml
+++ b/country-a-service/config/application.yml
@@ -20,7 +20,19 @@ server:
     key-password: Test.1234
 
 app:
-  fmk.endpoint.url: https://test2-cnsp.ekstern-test.nspop.dk:8443/decoupling
+  fmk:
+    endpoint.url: https://test2-cnsp.ekstern-test.nspop.dk:8443/decoupling
+    keystore:
+      path: "data/fmk-client.jks"
+      alias: "epps-sosi-sts-client"
+      password: ${FMK_KEYSTORE_PASSWORD:}
+  sosi:
+    endpoint.url: "https://test1-cnsp.ekstern-test.nspop.dk:8443/sts/services/DKNCPBST2EHDSIIdws"
+    issuer: "https://ehdsi-idp.testkald.nspop.dk"
+    keystore:
+      path: "data/epps-sosi-sts-client.jks"
+      alias: "epps-sosi-sts-client"
+      password: ${SOSI_KEYSTORE_PASSWORD:}
   cpr.endpoint.url: https://test2.ekstern-test.nspop.dk:8443/stamdata-cpr-ws/service/DetGodeCPROpslag-1.0.4
   minlog.endpoint.url: http://test1.ekstern-test.nspop.dk:8080/minlog2-registration/20250312/RegisterService
   authorization-registry.endpoint.url: https://test2.ekstern-test.nspop.dk:8443/stamdata-authorization-lookup-ws/service/AuthorizationCodeService-20240105

--- a/country-a-service/epps-application/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/config/AuthenticationServiceConfig.java
+++ b/country-a-service/epps-application/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/config/AuthenticationServiceConfig.java
@@ -3,6 +3,7 @@ package dk.sundhedsdatastyrelsen.ncpeh.config;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.AuthenticationService;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.Name;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -22,10 +23,15 @@ public record AuthenticationServiceConfig(
 
     @ConstructorBinding
     public AuthenticationServiceConfig(
+        @Name("endpoint.url")
         String uri,
+        @Name("keystore.path")
         String keystorePath,
+        @Name("keystore.alias")
         String keystoreAlias,
+        @Name("keystore.password")
         String keystorePassword,
+        @Name("issuer")
         String issuer
     ) throws IOException {
         this(URI.create(uri), new BufferedInputStream(Files.newInputStream(Path.of(keystorePath))), keystoreAlias, keystorePassword, issuer);

--- a/country-a-service/epps-application/src/test/resources/application-test.properties
+++ b/country-a-service/epps-application/src/test/resources/application-test.properties
@@ -23,11 +23,11 @@ app.cpr.endpoint.url=https://test2.ekstern-test.nspop.dk:8443/stamdata-cpr-ws/se
 app.authorization-registry.endpoint.url=https://test2.ekstern-test.nspop.dk:8443/stamdata-authorization-lookup-ws/service/AuthorizationCodeService-20240105
 app.fsk.endpoint.url=https://test2-cnsp.ekstern-test.nspop.dk:8443/decoupling
 app.minlog.endpoint.url=http://test1.ekstern-test.nspop.dk:8080/minlog2-registration/20250312/RegisterService
-app.sosi.uri=https://test1-cnsp.ekstern-test.nspop.dk:8443/sts/services/DKNCPBST2EHDSIIdws
+app.sosi.endpoint.url=https://test1-cnsp.ekstern-test.nspop.dk:8443/sts/services/DKNCPBST2EHDSIIdws
 app.sosi.issuer=https://ehdsi-idp.testkald.nspop.dk
-app.sosi.keystorePath=../config/dev-keystore.jks
-app.sosi.keystoreAlias=epps-country-a
-app.sosi.keystorePassword=Test.1234
+app.sosi.keystore.path=../config/dev-keystore.jks
+app.sosi.keystore.alias=epps-country-a
+app.sosi.keystore.password=Test.1234
 
 management.endpoint.health.show-details=always
 management.endpoint.health.probes.enabled=true


### PR DESCRIPTION
Update the app configuration so it can build again. Remark that it requires the certificates for SOSI and FMK, as well as their passwords for it to build.