### PR TITLE
Fix minlog endpoint

### DIFF
--- a/country-a-service/config/application.yml
+++ b/country-a-service/config/application.yml
@@ -22,7 +22,7 @@ server:
 app:
   fmk.endpoint.url: https://test2-cnsp.ekstern-test.nspop.dk:8443/decoupling
   cpr.endpoint.url: https://test2.ekstern-test.nspop.dk:8443/stamdata-cpr-ws/service/DetGodeCPROpslag-1.0.4
-  minlog.endpoint.url: https://test2-cnsp.ekstern-test.nspop.dk:8443/decoupling
+  minlog.endpoint.url: https://test1.ekstern-test.nspop.dk:8443/decoupling
   authorization-registry.endpoint.url: https://test2.ekstern-test.nspop.dk:8443/stamdata-authorization-lookup-ws/service/AuthorizationCodeService-20240105
   fsk.endpoint.url: https://test2-cnsp.ekstern-test.nspop.dk:8443/decoupling
 

--- a/country-a-service/config/application.yml
+++ b/country-a-service/config/application.yml
@@ -22,7 +22,7 @@ server:
 app:
   fmk.endpoint.url: https://test2-cnsp.ekstern-test.nspop.dk:8443/decoupling
   cpr.endpoint.url: https://test2.ekstern-test.nspop.dk:8443/stamdata-cpr-ws/service/DetGodeCPROpslag-1.0.4
-  minlog.endpoint.url: http://test1.ekstern-test.nspop.dk:8080/minlog2-registration/20250312/RegisterService
+  minlog.endpoint.url: https://test2-cnsp.ekstern-test.nspop.dk:8443/decoupling
   authorization-registry.endpoint.url: https://test2.ekstern-test.nspop.dk:8443/stamdata-authorization-lookup-ws/service/AuthorizationCodeService-20240105
   fsk.endpoint.url: https://test2-cnsp.ekstern-test.nspop.dk:8443/decoupling
 

--- a/country-a-service/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/MinLogClient.java
+++ b/country-a-service/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/MinLogClient.java
@@ -46,7 +46,7 @@ public class MinLogClient {
 
         return makeMinLogRequest(
             jaxbElement,
-            "AddRegistrations",
+            "AddRegistrations_20250312",
             RegistrationResponseType.class,
             caller
         );

--- a/country-a-service/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/MinLog.java
+++ b/country-a-service/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/MinLog.java
@@ -6,7 +6,7 @@ public class MinLog {
     private MinLog() {
     }
 
-    private static final String MINLOG_ENDPOINT_URI = "http://test1.ekstern-test.nspop.dk:8080/minlog2-registration/20250312/RegisterService";
+    private static final String MINLOG_ENDPOINT_URI = "https://test1.ekstern-test.nspop.dk:8443/decoupling/service/minlog20250312";
     /**
      * Jens Jensen is a test person we can see in the test person overview. Do not edit.
      */

--- a/country-a-service/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/MinLog.java
+++ b/country-a-service/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/MinLog.java
@@ -6,7 +6,7 @@ public class MinLog {
     private MinLog() {
     }
 
-    private static final String MINLOG_ENDPOINT_URI = "https://test1.ekstern-test.nspop.dk:8443/decoupling/service/minlog20250312";
+    private static final String MINLOG_ENDPOINT_URI = "https://test1.ekstern-test.nspop.dk:8443/decoupling";
     /**
      * Jens Jensen is a test person we can see in the test person overview. Do not edit.
      */


### PR DESCRIPTION
MinLog has deployed the newest version (which accepts European Healthcare Proffessional IDs) now on test1. I have updated the endpoints to fix the integration tests.