### PR TITLE
Fix configuration injection for sosi url

### DIFF
--- a/country-a-service/epps-application/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/Beans.java
+++ b/country-a-service/epps-application/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/Beans.java
@@ -47,7 +47,7 @@ public class Beans {
      */
     @Bean
     public NspDgwsIdentity.System systemIdentity(
-        @Value("app.sosi.endpoint.url") String systemStsUri,
+        @Value("${app.sosi.endpoint.url}") String systemStsUri,
         SigningCertificate signingCertificate
     ) {
         return new NspDgwsIdentity.System(URI.create(systemStsUri), signingCertificate.getCertificateAndKey());


### PR DESCRIPTION
The value "app.sosi.endpoint.url" was put into systemStsUri verbatim instead of being resolved from the config file.