### PR TITLE
give more information on rejection of dispensation

### DIFF
--- a/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PrescriptionService.java
+++ b/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PrescriptionService.java
@@ -271,13 +271,13 @@ public class PrescriptionService {
                 .filter(p -> p.getIdentifier() == prescriptionId)
                 .findFirst()
                 .orElseThrow(() -> new CountryAException(HttpStatus.NOT_FOUND, "Could not find prescription to dispense"));
-            var isDispensable = DispensationAllowed.isDispensationAllowed(
+            var dispensationAllowedError = DispensationAllowed.getDispensationRestrictions(
                 prescription,
                 lmsDataProvider.packageInfo(prescription.getPackageRestriction()
                     .getPackageNumber()
                     .getValue()));
-            if (!isDispensable) {
-                throw new CountryAException(HttpStatus.BAD_REQUEST, "Prescription is not allowed to be dispensed");
+            if (null != dispensationAllowedError) {
+                throw new CountryAException(HttpStatus.BAD_REQUEST, "Prescription is not allowed to be dispensed. " + dispensationAllowedError);
             }
         } catch (XPathExpressionException | MapperException | JAXBException e) {
             throw new CountryAException(HttpStatus.INTERNAL_SERVER_ERROR, "Could not fetch prescription to dispense", e);

--- a/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/EPrescriptionMetadataMapper.java
+++ b/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/EPrescriptionMetadataMapper.java
@@ -143,7 +143,7 @@ public class EPrescriptionMetadataMapper {
             // "When communicated, the Dose form text must be either in English or in (one of) the Country of affiliation national language(s)." 06.02
             drugForm.map(DrugFormType::getText).orElse(null),
             EPrescriptionL3Mapper.drugStrengthText(prescription),
-            DispensationAllowed.isDispensationAllowed(prescription, packageInfo)
+            DispensationAllowed.getDispensationRestrictions(prescription, packageInfo) == null
         );
     }
 


### PR DESCRIPTION
When testing or investigating errors, it is helpful to know the reason a specific prescription was not allowed to be dispensed.