### PR TITLE
remove hardcoded CPR

### DIFF
--- a/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/DispensationMapper.java
+++ b/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/DispensationMapper.java
@@ -248,9 +248,6 @@ public class DispensationMapper {
             .withName()
             .withSurname(familyNames.getLast())
             .withGivenName(allButLastName).end()
-            // without the following ID the FMK request fails with:
-            // Identifier anvendt i certifikatet CPR:3001010033 stemmer ikke overens med identifier i modifikator-elementet (CreatedBy/ModifiedBy/...) CPR:null
-            .withPersonIdentifier().withSource("CPR").withValue("3001010033").end()
             .build();
     }
 

--- a/country-a-service/epps-service/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/DispensationMapperTest.java
+++ b/country-a-service/epps-service/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/DispensationMapperTest.java
@@ -84,9 +84,7 @@ class DispensationMapperTest {
         var cda = testDispensationCda(xmlFileName);
         var person = DispensationMapper.authorPerson(cda);
 
-        Assertions.assertNotNull(person.getPersonIdentifier());
-        Assertions.assertEquals("CPR", person.getPersonIdentifier().getSource());
-        Assertions.assertEquals("3001010033", person.getPersonIdentifier().getValue());
+        Assertions.assertNull(person.getPersonIdentifier());
 
         Assertions.assertFalse(person.getName().getGivenName().isBlank());
         Assertions.assertEquals("TOMÁŠ", person.getName().getGivenName());


### PR DESCRIPTION
We don't use Chris for FMK requests anymore, so his CPR number should not be put in the modificator field.