### PR TITLE
update wss4j to 4.0.0

### DIFF
--- a/country-a-service/authentication/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/CertificateUtils.java
+++ b/country-a-service/authentication/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/CertificateUtils.java
@@ -41,8 +41,7 @@ public class CertificateUtils {
     @NonNull
     public static CertificateAndKey loadCertificateFromKeystore(InputStream is, String keyAlias, String password) throws AuthenticationException {
         try {
-            // Have to use jks because initializing wss4j causes parsing keys from pkcs12 keystores to fail.
-            // See also where we call WSSConfig.init, currently in NspClientIdws.
+            // keystore type is changed once we load the keystore, so it doesn't matter what we put in this constructor.
             var ks = KeyStore.getInstance("jks");
             ks.load(is, password.toCharArray());
             return new CertificateAndKey(

--- a/country-a-service/nsp-client/pom.xml
+++ b/country-a-service/nsp-client/pom.xml
@@ -54,8 +54,8 @@
             <artifactId>spring-context</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.ws.security</groupId>
-            <artifactId>wss4j</artifactId>
+            <groupId>org.apache.wss4j</groupId>
+            <artifactId>wss4j-ws-security-dom</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/country-a-service/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/NspClientIdws.java
+++ b/country-a-service/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/NspClientIdws.java
@@ -4,8 +4,8 @@ import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpIdwsToken;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.XPathWrapper;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.XmlNamespace;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.XmlUtils;
-import org.apache.ws.security.WSSConfig;
-import org.apache.ws.security.transform.STRTransform;
+import org.apache.wss4j.dom.engine.WSSConfig;
+import org.apache.wss4j.dom.transform.STRTransform;
 import org.slf4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -41,9 +41,6 @@ public class NspClientIdws {
 
     static {
         // WSS init is idempotent, but not threadsafe, so we make sure we only do it once.
-        // Loading keys from pkcs12 keystores after this initialization has been called will fail in the version of
-        // wss4j we're using (1.6.4). So we need to use jks. Once we can update wss4j, we should test if it works with
-        // pkcs12.
         WSSConfig.init();
     }
 

--- a/country-a-service/pom.xml
+++ b/country-a-service/pom.xml
@@ -184,15 +184,9 @@
                 <version>3.47.0.0</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.ws.security</groupId>
-                <artifactId>wss4j</artifactId>
-                <version>1.6.4</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
+                <groupId>org.apache.wss4j</groupId>
+                <artifactId>wss4j-ws-security-dom</artifactId>
+                <version>4.0.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
@@ -211,12 +205,29 @@
                 <artifactId>checker-qual</artifactId>
                 <version>3.37.0</version>
             </dependency>
+            <!-- Convergence errors for wss4j -->
             <dependency>
                 <groupId>org.apache.santuario</groupId>
                 <artifactId>xmlsec</artifactId>
-                <version>1.5.8</version>
+                <version>4.0.3</version>
             </dependency>
-            <!-- Solve convergence errors -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>33.4.0-jre</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>1.78.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.78.1</version>
+            </dependency>
+            <!-- /Convergence errors for wss4j -->
+            <!-- /Solve convergence errors -->
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This fixes several security issues. I've tested calls against FMK, where this is used, and there were no errors. I've also tested that we can use pkcs12 files now.