### PR TITLE
block locked, partially dispensed, and iterated prescriptions

### DIFF
--- a/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PrescriptionService.java
+++ b/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PrescriptionService.java
@@ -146,6 +146,7 @@ public class PrescriptionService {
             final var request = GetPrescriptionRequestType.builder()
                 .withPersonIdentifier().withSource("CPR").withValue(cpr).end()
                 .withIncludeOpenPrescriptions().end()
+                .withIncludeEffectuations(true)
                 .build();
             var fmkResponse = fmkClient.getPrescription(request, token);
 
@@ -264,6 +265,7 @@ public class PrescriptionService {
                 GetPrescriptionRequestType.builder()
                     .withPersonIdentifier().withSource("CPR").withValue(PatientIdMapper.toCpr(patientId)).end()
                     .withIncludeOpenPrescriptions().end()
+                    .withIncludeEffectuations(true)
                     .build(),
                 token);
             var prescription = prescriptionResponse.getPrescription()

--- a/country-a-service/epps-service/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/service/DispensationAllowedTest.java
+++ b/country-a-service/epps-service/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/service/DispensationAllowedTest.java
@@ -1,0 +1,82 @@
+package dk.sundhedsdatastyrelsen.ncpeh.service;
+
+import dk.dkma.medicinecard.xml_schema._2015._06._01.OrderStatusPredefinedType;
+import dk.dkma.medicinecard.xml_schema._2015._06._01.e6.PrescriptionType;
+import dk.sundhedsdatastyrelsen.ncpeh.locallms.PackageInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class DispensationAllowedTest {
+    @Test
+    void happyPathPrescriptionIsAllowed() {
+        var p = PrescriptionType.builder().build();
+        var res = DispensationAllowed.getDispensationRestrictions(
+            p,
+            new PackageInfo("", "A", "", 1));
+        assertThat(res, is(nullValue()));
+    }
+
+    @Test
+    void lockedPrescriptionsAreNotAllowed() {
+        var pInfo = new PackageInfo("", "A", "", 1);
+        var effectuationStarted = PrescriptionType.builder()
+            .addOrder()
+            .withStatus("Ekspedition påbegyndt")
+            .end()
+            .build();
+        var orderedPrescription = PrescriptionType.builder()
+            .addOrder()
+            .withStatus(OrderStatusPredefinedType.BESTILT.value())
+            .end()
+            .build();
+        var res1 = DispensationAllowed.getDispensationRestrictions(effectuationStarted, pInfo);
+        var res2 = DispensationAllowed.getDispensationRestrictions(orderedPrescription, pInfo);
+        assertThat(res1, is("Prescription is locked to another pharmacy, and cannot be dispensed cross border."));
+        assertThat(res2, is("Prescription is locked to another pharmacy, and cannot be dispensed cross border."));
+    }
+
+    @Test
+    void prescriptionsWithPastDispensationsAreNotAllowed() {
+        var completedPrescription = PrescriptionType.builder()
+            .addOrder()
+            .withStatus("Udført")
+            .end()
+            .build();
+        var dosisDispensedPrescription = PrescriptionType.builder()
+            .addOrder()
+            .withStatus(OrderStatusPredefinedType.DOSISDISPENSERET.value())
+            .end()
+            .build();
+        var pInfo = new PackageInfo("", "A", "", 1);
+        var res1 = DispensationAllowed.getDispensationRestrictions(completedPrescription, pInfo);
+        var res2 = DispensationAllowed.getDispensationRestrictions(dosisDispensedPrescription, pInfo);
+        assertThat(res1, is("Prescription has been partially dispensed. This is not yet supported in DK."));
+        assertThat(res2, is("Prescription has been partially dispensed. This is not yet supported in DK."));
+    }
+
+    @Test
+    void prescriptionsWithCancelledPastDispensationsAreAllowed() {
+        var prescription = PrescriptionType.builder()
+            .addOrder()
+            .withStatus("Annulleret")
+            .end()
+            .build();
+        var pInfo = new PackageInfo("", "A", "", 1);
+        var res1 = DispensationAllowed.getDispensationRestrictions(prescription, pInfo);
+        assertThat(res1, is(nullValue()));
+    }
+
+    @Test
+    void iteratedPrescriptionsAreBlocked() {
+        var prescription = PrescriptionType.builder()
+            .withPackageRestriction()
+            .withIterationNumber(2)
+            .end()
+            .build();
+        var pInfo = new PackageInfo("", "A", "", 1);
+        var res1 = DispensationAllowed.getDispensationRestrictions(prescription, pInfo);
+        assertThat(res1, is("Prescription is iterated, which is not yet supported in DK."));
+    }
+}


### PR DESCRIPTION
We're currently investigating what the right solution to partially dispensed and iterated prescriptions is. Until we get an answer, they're not supported.

Locked prescriptions should just not be dispensable.

I'm also investigating whether "Bestilt" should be blocking. Until we know, it should be blocked.

Related to #328 and #205 