### PR TITLE
Fix integration tests on test2

### DIFF
--- a/country-a-service/epps-api/autorisationsregister-model/readme.md
+++ b/country-a-service/epps-api/autorisationsregister-model/readme.md
@@ -1,6 +1,6 @@
 # Authorization registry integration
 
 The interface is documented at https://www.nspop.dk/display/public/web/SDM+-+Guide+til+anvendere#SDMGuidetilanvendere-5.5Enkeltopslagiyderregistret,
-where they also link to the wsdl which is at http://test1-cnsp.ekstern-test.nspop.dk:8080/stamdata-authorization-lookup-ws/service/AuthorizationService-20240105?wsdl.
+where they also link to the wsdl which is at http://test2-cnsp.ekstern-test.nspop.dk:8080/stamdata-authorization-lookup-ws/service/AuthorizationService-20240105?wsdl.
 
 Remark that we need the 2024-01-05 version, as we also need the specializations of the health personnel.

--- a/country-a-service/epps-api/autorisationsregister-model/src/main/resources/AuthorizationService-20240105.wsdl
+++ b/country-a-service/epps-api/autorisationsregister-model/src/main/resources/AuthorizationService-20240105.wsdl
@@ -167,14 +167,14 @@
     <wsdl:port binding="tns:AuthorizationBinding" name="AuthorizationPort">
       <!-- The following is required in the wsdl, but the actual url is defined 
         elsewhere -->
-      <soap:address location="http://test1-cnsp.ekstern-test.nspop.dk:8080/stamdata-authorization-lookup-ws/service/AuthorizationService-20240105"/>
+      <soap:address location="http://test2-cnsp.ekstern-test.nspop.dk:8080/stamdata-authorization-lookup-ws/service/AuthorizationService-20240105"/>
     </wsdl:port>
   </wsdl:service>
   <wsdl:service name="AuthorizationCodeService">
     <wsdl:port binding="tns:AuthorizationCodeBinding" name="AuthorizationCodePort">
       <!-- The following is required in the wsdl, but the actual url is defined 
         elsewhere -->
-      <soap:address location="http://test1-cnsp.ekstern-test.nspop.dk:8080/stamdata-authorization-lookup-ws/service/AuthorizationCodeService-20240105"/>
+      <soap:address location="http://test2-cnsp.ekstern-test.nspop.dk:8080/stamdata-authorization-lookup-ws/service/AuthorizationCodeService-20240105"/>
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>

--- a/country-a-service/epps-api/autorisationsregister-model/src/main/resources/fetch_wsdl.clj
+++ b/country-a-service/epps-api/autorisationsregister-model/src/main/resources/fetch_wsdl.clj
@@ -79,7 +79,7 @@
        (run! #(fix-schema-locations % "./"))))
 
 (def wsdl-url
-  "http://test1-cnsp.ekstern-test.nspop.dk:8080/stamdata-authorization-lookup-ws/service/AuthorizationService-20240105?wsdl")
+  "http://test2-cnsp.ekstern-test.nspop.dk:8080/stamdata-authorization-lookup-ws/service/AuthorizationService-20240105?wsdl")
 
 (when (= *file* (System/getProperty "babashka.file"))
   (fetch-wsdl wsdl-url "AuthorizationService-20240105.wsdl"))

--- a/country-a-service/epps-api/epps-minlog-api/src/main/resources/wsdl/fetch_wsdl.clj
+++ b/country-a-service/epps-api/epps-minlog-api/src/main/resources/wsdl/fetch_wsdl.clj
@@ -79,7 +79,7 @@
        (run! #(fix-schema-locations % "./"))))
 
 (def minlog-wsdl-url
-  "http://test1.ekstern-test.nspop.dk:8080/minlog2-registration/20250312/RegisterService?wsdl")
+  "http://test2.ekstern-test.nspop.dk:8080/minlog2-registration/20250312/RegisterService?wsdl")
 
 (when (= *file* (System/getProperty "babashka.file"))
   (fetch-wsdl minlog-wsdl-url "minlog.wsdl"))

--- a/country-a-service/epps-api/epps-minlog-api/src/main/resources/wsdl/minlog.wsdl
+++ b/country-a-service/epps-api/epps-minlog-api/src/main/resources/wsdl/minlog.wsdl
@@ -36,7 +36,7 @@
   </wsdl:binding>
   <wsdl:service name="RegisterService">
     <wsdl:port binding="tns:RegisterServiceBinding" name="RegisterServicePort">
-      <soap:address location="http://test1.ekstern-test.nspop.dk:8080/minlog2-registration/20250312/RegisterService"/>
+      <soap:address location="http://test2.ekstern-test.nspop.dk:8080/minlog2-registration/20250312/RegisterService"/>
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>

--- a/country-a-service/epps-application/src/test/resources/application-test.properties
+++ b/country-a-service/epps-application/src/test/resources/application-test.properties
@@ -22,9 +22,9 @@ app.fmk.endpoint.url=https://test2-cnsp.ekstern-test.nspop.dk:8443/decoupling
 app.cpr.endpoint.url=https://test2.ekstern-test.nspop.dk:8443/stamdata-cpr-ws/service/DetGodeCPROpslag-1.0.4
 app.authorization-registry.endpoint.url=https://test2.ekstern-test.nspop.dk:8443/stamdata-authorization-lookup-ws/service/AuthorizationCodeService-20240105
 app.fsk.endpoint.url=https://test2-cnsp.ekstern-test.nspop.dk:8443/decoupling
-app.minlog.endpoint.url=http://test1.ekstern-test.nspop.dk:8080/minlog2-registration/20250312/RegisterService
-app.sosi.endpoint.url=https://test1-cnsp.ekstern-test.nspop.dk:8443/sts/services/DKNCPBST2EHDSIIdws
-app.sosi-system-dgws.endpoint.url=http://test1.ekstern-test.nspop.dk:8080/sts/services/NewSecurityTokenService
+app.minlog.endpoint.url=http://test2.ekstern-test.nspop.dk:8080/minlog2-registration/20250312/RegisterService
+app.sosi.endpoint.url=https://test2-cnsp.ekstern-test.nspop.dk:8443/sts/services/DKNCPBST2EHDSIIdws
+app.sosi-system-dgws.endpoint.url=http://test2.ekstern-test.nspop.dk:8080/sts/services/NewSecurityTokenService
 app.sosi.issuer=https://ehdsi-idp.testkald.nspop.dk
 
 management.endpoint.health.show-details=always

--- a/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/DispensationMapper.java
+++ b/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/DispensationMapper.java
@@ -209,6 +209,8 @@ public class DispensationMapper {
             "/hl7:ClinicalDocument/hl7:id";
     }
 
+    public static final String EHDSI_EAN = "5790001392277"; // NSI, Udenlandsk Apotek via epSOS ( SOR-nummer: 397941000016003 )
+
     // XPath is not thread safe so we keep a separate copy for each thread.
     private static final ThreadLocal<XPath> xpath = ThreadLocal.withInitial(() -> {
         var xp = XPathFactory.newInstance().newXPath();
@@ -285,7 +287,7 @@ public class DispensationMapper {
     private static OrganisationIdentifierType placeholderPharmacyId() {
         return OrganisationIdentifierType.builder()
             .withSource(OrganisationIdentifierPredefinedSourceType.EAN_LOKATIONSNUMMER.value())
-            .withValue("5790001392277") // NSI, Udenlandsk Apotek via epSOS ( SOR-nummer: 397941000016003 )
+            .withValue(EHDSI_EAN)
             .build();
     }
 

--- a/country-a-service/epps-service/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/service/DispensationAllowedTest.java
+++ b/country-a-service/epps-service/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/service/DispensationAllowedTest.java
@@ -26,15 +26,8 @@ class DispensationAllowedTest {
             .withStatus("Ekspedition påbegyndt")
             .end()
             .build();
-        var orderedPrescription = PrescriptionType.builder()
-            .addOrder()
-            .withStatus(OrderStatusPredefinedType.BESTILT.value())
-            .end()
-            .build();
         var res1 = DispensationAllowed.getDispensationRestrictions(effectuationStarted, pInfo);
-        var res2 = DispensationAllowed.getDispensationRestrictions(orderedPrescription, pInfo);
         assertThat(res1, is("Prescription is locked to another pharmacy, and cannot be dispensed cross border."));
-        assertThat(res2, is("Prescription is locked to another pharmacy, and cannot be dispensed cross border."));
     }
 
     @Test
@@ -58,14 +51,21 @@ class DispensationAllowedTest {
 
     @Test
     void prescriptionsWithCancelledPastDispensationsAreAllowed() {
-        var prescription = PrescriptionType.builder()
+        var cancelledPrescription = PrescriptionType.builder()
             .addOrder()
             .withStatus("Annulleret")
             .end()
             .build();
+        var orderedPrescription = PrescriptionType.builder()
+            .addOrder()
+            .withStatus(OrderStatusPredefinedType.BESTILT.value())
+            .end()
+            .build();
         var pInfo = new PackageInfo("", "A", "", 1);
-        var res1 = DispensationAllowed.getDispensationRestrictions(prescription, pInfo);
+        var res1 = DispensationAllowed.getDispensationRestrictions(cancelledPrescription, pInfo);
+        var res2 = DispensationAllowed.getDispensationRestrictions(orderedPrescription, pInfo);
         assertThat(res1, is(nullValue()));
+        assertThat(res2, is(nullValue()));
     }
 
     @Test

--- a/country-a-service/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Fmk.java
+++ b/country-a-service/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Fmk.java
@@ -16,9 +16,9 @@ import java.util.Base64;
 public class Fmk {
     private Fmk() {}
 
-    private static final String FMK_ENDPOINT_URI = "https://test2-cnsp.ekstern-test.nspop.dk:8443/decoupling";
+    public static final String FMK_DGWS_ENDPOINT_URI = "https://test2-cnsp.ekstern-test.nspop.dk:8443/decoupling";
 
-    public static final String FMK_IDWS_ENDPOINT_URI = "https://test1.fmk.netic.dk/idws_xua/fmk_xua_146_E6";
+    public static final String FMK_IDWS_ENDPOINT_URI = "https://test2.fmk.netic.dk/idws_xua/fmk_xua_146_E6";
 
     /**
      * Helle Bonde is a test persona which we do *not* own, so we should only perform read operations on her.

--- a/country-a-service/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Fsk.java
+++ b/country-a-service/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Fsk.java
@@ -6,7 +6,8 @@ import dk.sundhedsdatastyrelsen.ncpeh.client.FskClient;
  * API client for FSK test environment
  */
 public class Fsk {
-    private static final String fskEndpointUri = "http://test1.ekstern-test.nspop.dk:8080/decoupling";
+    private static final String fskEndpointUri = "http://test2.ekstern-test.nspop.dk:8080/decoupling";
+
     /**
      * Jens Jensen is a test person vi can see in the test person overview. Do not edit.
      */

--- a/country-a-service/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/MinLog.java
+++ b/country-a-service/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/MinLog.java
@@ -6,7 +6,7 @@ public class MinLog {
     private MinLog() {
     }
 
-    private static final String MINLOG_ENDPOINT_URI = "https://test1.ekstern-test.nspop.dk:8443/decoupling";
+    private static final String MINLOG_ENDPOINT_URI = "https://test2.ekstern-test.nspop.dk:8443/decoupling";
     /**
      * Jens Jensen is a test person we can see in the test person overview. Do not edit.
      */

--- a/country-a-service/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Sosi.java
+++ b/country-a-service/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Sosi.java
@@ -15,6 +15,9 @@ import java.util.Base64;
 public class Sosi {
     private static AuthenticationService authService;
     private static String soapHeader;
+    private static final URI sosiUri = URI.create("https://test2-cnsp.ekstern-test.nspop.dk:8443/sts/services/DKNCPBST2EHDSIIdws");
+    public static final URI sosiOrganisationDgwsUri = URI.create("http://test2.ekstern-test.nspop.dk:8080/sts/services/NewSecurityTokenService");
+    public static final URI sosiPersonalDgwsUri = URI.create("http://test2.ekstern-test.nspop.dk:8080/sts/services/BST2SOSI");
 
     @SneakyThrows
     public static EuropeanHcpIdwsToken getToken() {
@@ -31,7 +34,7 @@ public class Sosi {
                 password);
 
             authService = new AuthenticationService(
-                URI.create("https://test1-cnsp.ekstern-test.nspop.dk:8443/sts/services/DKNCPBST2EHDSIIdws"),
+                sosiUri,
                 signingKey,
                 "https://ehdsi-idp.testkald.nspop.dk");
         }

--- a/country-a-service/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/TestIdentities.java
+++ b/country-a-service/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/TestIdentities.java
@@ -4,7 +4,6 @@ import dk.sundhedsdatastyrelsen.ncpeh.authentication.AuthenticationException;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.CertificateUtils;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 
-import java.net.URI;
 import java.util.UUID;
 
 public class TestIdentities {
@@ -33,24 +32,24 @@ public class TestIdentities {
                 "Test1234"
             );
             apotekerChrisChristoffersen = new NspDgwsIdentity.ReplaceWithIdws(
-                URI.create("http://test1.ekstern-test.nspop.dk:8080/sts/services/BST2SOSI"),
+                Sosi.sosiPersonalDgwsUri,
                 systemCert,
                 UUID.fromString("1fdff71e-2697-4f84-8611-e890a422cef8"),
                 idpCert);
             apotekerJeppeMoeller = new NspDgwsIdentity.ReplaceWithIdws(
-                URI.create("http://test1.ekstern-test.nspop.dk:8080/sts/services/BST2SOSI"),
+                Sosi.sosiPersonalDgwsUri,
                 systemCert,
                 UUID.fromString("00798849-effe-4733-bcc4-670093830511"),
                 idpCert
             );
             lægeCharlesBabbage = new NspDgwsIdentity.ReplaceWithIdws(
-                URI.create("http://test1.ekstern-test.nspop.dk:8080/sts/services/BST2SOSI"),
+                Sosi.sosiPersonalDgwsUri,
                 systemCert,
                 UUID.fromString("46559bb9-d720-48b7-b9bd-c280915768d0"),
                 idpCert
             );
             systemIdentity = new NspDgwsIdentity.System(
-                URI.create("http://test1.ekstern-test.nspop.dk:8080/sts/services/NewSecurityTokenService"),
+                Sosi.sosiOrganisationDgwsUri,
                 systemCert);
         } catch (AuthenticationException e) {
             throw new RuntimeException(e);

--- a/country-a-service/testing-tools/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/script/FmkPrescriptionCreator.java
+++ b/country-a-service/testing-tools/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/script/FmkPrescriptionCreator.java
@@ -282,7 +282,7 @@ public class FmkPrescriptionCreator {
         }
         try {
             body = NspClientDgws.request(
-                URI.create("https://test1-cnsp.ekstern-test.nspop.dk:8443/decoupling"),
+                URI.create(Fmk.FMK_DGWS_ENDPOINT_URI),
                 ClientUtils.toElement(jaxbContext, request),
                 soapAction,
                 identity,


### PR DESCRIPTION
Integration tests on test2 are failing, because the logic for when a prescription is dispensable didn't match reality. It was hard to test that on test1, as we were not allowed to automatically create prescriptions there.

All endpoints have been moved to test2, and "bestilt" is not a blocking status for a prescription.