### PR TITLE
add integration test of abort

### DIFF
--- a/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PrescriptionService.java
+++ b/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PrescriptionService.java
@@ -251,8 +251,13 @@ public class PrescriptionService {
         }
     }
 
-    @WithSpan
     public void submitDispensation(@NonNull String patientId, @NonNull Document dispensationCda, EuropeanHcpIdwsToken token) {
+        submitDispensation(patientId, dispensationCda, token, false);
+    }
+
+    /// @hidden public for testing.
+    @WithSpan
+    public void submitDispensation(@NonNull String patientId, @NonNull Document dispensationCda, EuropeanHcpIdwsToken token, boolean forceDispensationError) {
         var helper = new SubmitDispensationHelper();
         var eDispensationCdaId = SubmitDispensationHelper.getEDispensationId(dispensationCda);
 
@@ -266,6 +271,9 @@ public class PrescriptionService {
         try {
             // Dispense it. This may also close the prescription.
             log.info("Create FMK pharmacy effectuation");
+            if (forceDispensationError) {
+                throw new IllegalStateException("Forced dispensation error");
+            }
             var dispensation = helper.dispense(patientId, dispensationCda, token, startEffectuation.response());
 
             // If we didn't terminate, release the lock on the prescription again.


### PR DESCRIPTION
There was no great way to do this. Either I had to rewrite most of submitDispensation in the test, which was a lot of work, or I had to do something to make submitDispensation fail in the right way. In the end I opted for a solution that was at least clear in intent, and something that makes it easy to force aborts for official test rounds as well.