### PR TITLE
remove FMK workaround, remove FMK whitelisting header

### DIFF
--- a/country-a-service/epps-api/epps-fmk-api/src/main/resources/wsdl/MedicineCard-inline_2015_06_01_E6.wsdl
+++ b/country-a-service/epps-api/epps-fmk-api/src/main/resources/wsdl/MedicineCard-inline_2015_06_01_E6.wsdl
@@ -7342,9 +7342,7 @@ Name of a village, city or subdivision of a city or district, which is determine
 
 	<xs:simpleType name="PersonIdentifierValueType">
 		<xs:restriction base="xs:string">
-                        <!-- TODO: This has been changed from 1 to 0, because we're actually required to send an empty value here.
-                              FMK has been notified of the discrepancy. -->
-			<xs:minLength value="0"/>
+			<xs:minLength value="1"/>
 			<xs:maxLength value="50"/>
 		</xs:restriction>
 	</xs:simpleType>

--- a/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/DispensationMapper.java
+++ b/country-a-service/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/DispensationMapper.java
@@ -256,11 +256,6 @@ public class DispensationMapper {
             .withSurname(familyNames.getLast())
             .withGivenName(allButLastName)
             .end()
-            // FMK's undo requires personidentifier to not be null, but it can't have a value, so this is what has been
-            // agreed with them to work. See FmkIT for where we test it.
-            .withPersonIdentifier()
-            .withSource("Udenlandsk")
-            .end()
             .build();
     }
 

--- a/country-a-service/epps-service/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/DispensationMapperTest.java
+++ b/country-a-service/epps-service/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/service/mapping/DispensationMapperTest.java
@@ -86,13 +86,9 @@ class DispensationMapperTest {
         var person = DispensationMapper.authorPerson(cda);
 
         assertThat(
-            "FMK validates the modifier heavily. It must be of type OtherPerson and ID must be there, with an " +
-                "empty value and source 'Udenlandsk'. They take the ID from the XUA IDWS header. This is not specified " +
-                "anywhere yet, I think, but was discovered while both teams worked on this.",
+            "Person identifier must be null in IDWS XUA calls to FMK. This was decided by the teams.",
             person.getPersonIdentifier(),
-            is(not(nullValue())));
-        assertThat(person.getPersonIdentifier().getValue(), is(nullValue()));
-        assertThat(person.getPersonIdentifier().getSource(), is("Udenlandsk"));
+            is(nullValue()));
 
         assertThat(person.getName().getGivenName(), is("TOMÁŠ"));
 


### PR DESCRIPTION
FMK has released a fix for the schema validation problem, so we no longer fail schema validation.

Additionally, they realized that we don't need the whitelisting header anymore, since they pull the data from the IDWS XUA header, so the whitelisting header has also been removed.