### PR TITLE
handle prescription dosage differs from medication dosage

### DIFF
--- a/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
+++ b/country-a-service/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3Mapper.java
@@ -100,14 +100,14 @@ public class EPrescriptionL3Mapper {
 
         if (medication.isPresent()) {
             var drugMedicationType = medication.get();
-            var dosage = DosageMapper.model(drugMedicationType.getDosage());
+            var dosage = DosageMapper.model(drugMedicationType.getDosage(), prescription.getDosageText());
             if (dosage instanceof Dosage.Unstructured unstructured) {
                 log.info("Dosage could not be mapped. Reason: {}", unstructured.getReason());
             }
             prescriptionBuilder
                 .medicationStartTime(Utils.convertToOffsetDateTime(drugMedicationType.getBeginEndDate()
                     .getTreatmentStartDate()))
-                .dosage(DosageMapper.model(drugMedicationType.getDosage()))
+                .dosage(dosage)
                 .medicationEndTime(Utils.convertToOffsetDateTime(drugMedicationType.getBeginEndDate()
                     .getTreatmentEndDate()));
 


### PR DESCRIPTION
Doctors can choose to override the dosage, when they create a prescription from a drug medication. We now handle this case.

The logic to determine whether the dosage has been overridden depends on default strings used by FMK, which is not ideal, but there is no other way currently.

Additionally add short texts to the unstructured texts, as it may happen that there is only a short text.

Closes #366 