### PR TITLE
Fix docker image build

### DIFF
--- a/country-a-service/.dockerignore
+++ b/country-a-service/.dockerignore
@@ -5,6 +5,6 @@
 Dockerfile
 docker-compose.yml
 README.md
-config/
-!config/dev-keystore.jks
+config/application.yml
+config/application-docker.yml
 FMK-soapui-project.xml


### PR DESCRIPTION
The unit test suite didn't succeed in the docker image build because the test opt out keystores were not available to the docker daemon.