### PR TITLE
use a test person we own for ddv

### DIFF
--- a/country-a-service/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/DdvIT.java
+++ b/country-a-service/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/DdvIT.java
@@ -2,6 +2,7 @@ package dk.sundhedsdatastyrelsen.ncpeh;
 
 import dk.sundhedsdatastyrelsen.ncpeh.service.VaccinationService;
 import dk.sundhedsdatastyrelsen.ncpeh.testing.shared.Ddv;
+import dk.sundhedsdatastyrelsen.ncpeh.testing.shared.Fmk;
 import dk.sundhedsdatastyrelsen.ncpeh.testing.shared.Sosi;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +15,7 @@ class DdvIT {
     @Test
     void getVaccinationTest() throws Exception {
         var token = Sosi.getToken(Sosi.Audience.DDV);
-        var vaccinations = vaccinationService.getVaccinationsForCpr("1111111118", token);
+        var vaccinations = vaccinationService.getVaccinationsForCpr(Fmk.cprKarl, token);
         assertThat(vaccinations, is(not(empty())));
     }
 }


### PR DESCRIPTION
The previous test person we did not own. This one we do. I've created a vaccination on him, and the test is green again now.