### PR TITLE
document how application.yml is picked up

### DIFF
--- a/national-connector/config/application.yml
+++ b/national-connector/config/application.yml
@@ -11,6 +11,8 @@ spring:
     enabled: true
     locations: "classpath:db/migration"
 
+# This is automatically picked up by Spring boot.
+# See https://docs.spring.io/spring-boot/how-to/webserver.html#howto.webserver.configure-ssl
 server:
   port: 4443
   ssl:
@@ -19,7 +21,7 @@ server:
     key-alias: national-connector
     key-password: Test.1234
 
-# The certificate used for signing our requests to the national services.
+# The certificate used for signing our requests to the national services. Picked up in Beans.java.
 signing-certificate-keystore:
   path: "data/epps-sosi-sts-client.jks"
   alias: "epps-sosi-sts-client"


### PR DESCRIPTION
While I was trying to fix the certificates in the integration tests, I spent a while understanding how the ssl certificate for the national connector gets from the configuration into the service. This documents how that works so I can save the time next time.