### PR TITLE
always use latest NCP in training

### DIFF
--- a/.github/workflows/deploy-country-a-to-server.yml
+++ b/.github/workflows/deploy-country-a-to-server.yml
@@ -2,7 +2,7 @@ name: Deploy country A service with Docker Compose
 
 on:
   workflow_run:
-    workflows: 
+    workflows:
       - "Country A Docker Images"
     types:
       - "completed"
@@ -38,8 +38,8 @@ jobs:
             echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
             # 3. Pull the Docker images (if any are specified in the docker-compose.yml)
-            IMAGE_TAG=${{ github.sha }} docker compose pull 
+            docker compose pull 
 
             # 4. Deploy the services
-            IMAGE_TAG=${{ github.sha }} docker compose up -d 
+            docker compose up -d 
           EOF

--- a/.github/workflows/deploy-ncp-to-server.yml
+++ b/.github/workflows/deploy-ncp-to-server.yml
@@ -38,8 +38,8 @@ jobs:
             echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
             # 3. Pull the Docker images (if any are specified in the docker-compose.yml)
-            IMAGE_TAG=${{ github.sha }} docker compose pull 
+            docker compose pull 
 
             # 4. Deploy the services
-            IMAGE_TAG=${{ github.sha }} docker compose up -d 
+            docker compose up -d 
           EOF


### PR DESCRIPTION
IMAGE_TAG is set in `.env` in training. This change ensures that running `docker compose up` directly on the server will perform the same update as github actions does, which was not previously the case.