### PR TITLE
use the created prescription in the dispensation test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,14 +26,15 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Build with Maven
-        run:  |
+        run: |
           cd national-connector
           mvn --batch-mode --projects testing-tools --also-make -DskipUTs package
       - name: Create a new prescription in FMK
         run: |
           java -cp national-connector/testing-tools/target/testing-tools-1.0.0-SNAPSHOT-shaded.jar \
           dk.sundhedsdatastyrelsen.ncpeh.script.FmkPrescriptionCreator \
-          0201909309
+          0201909309 \
+          target/test-files/prescription-id.txt
       - name: Get the prescription from FMK
         run: |
           java -cp national-connector/testing-tools/target/testing-tools-1.0.0-SNAPSHOT-shaded.jar \
@@ -45,6 +46,7 @@ jobs:
         run: |
           java -cp national-connector/testing-tools/target/testing-tools-1.0.0-SNAPSHOT-shaded.jar \
           dk.sundhedsdatastyrelsen.ncpeh.script.EPrescriptionCdaGenerator \
+          target/test-files/prescription-id.txt \
           target/test-files/get-prescription.xml \
           target/test-files/drug-medication.xml \
           target/test-files/eprescription-cda.xml

--- a/national-connector/testing-tools/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/script/EPrescriptionCdaGenerator.java
+++ b/national-connector/testing-tools/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/script/EPrescriptionCdaGenerator.java
@@ -4,7 +4,6 @@ import dk.sundhedsdatastyrelsen.ncpeh.cda.EPrescriptionL3Generator;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.EPrescriptionL3Input;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.MapperException;
 import dk.sundhedsdatastyrelsen.ncpeh.testing.shared.FmkResponseStorage;
-import freemarker.template.TemplateException;
 import jakarta.xml.bind.JAXBException;
 
 import java.io.IOException;
@@ -14,20 +13,25 @@ import java.nio.file.Path;
 
 @SuppressWarnings("java:S106") // don't complain about System.out
 public class EPrescriptionCdaGenerator {
-    public static void main(String[] args) throws TemplateException, JAXBException, MapperException, IOException {
-        var prescriptionInput = "target/test-files/get-prescription.xml";
+    public static void main(String[] args) throws JAXBException, MapperException, IOException {
+        String prescriptionIdPath = "target/test-files/prescription-id.txt";
         if (args.length > 0) {
-            prescriptionInput = args[0];
+            prescriptionIdPath = args[0];
+        }
+
+        var prescriptionInput = "target/test-files/get-prescription.xml";
+        if (args.length > 1) {
+            prescriptionInput = args[1];
         }
 
         var medicationInput = "target/test-files/drug-medication.xml";
-        if (args.length > 1) {
-            medicationInput = args[1];
+        if (args.length > 2) {
+            medicationInput = args[2];
         }
 
         var cdaOutput = "target/test-files/eprescription-cda.xml";
-        if (args.length > 2) {
-            cdaOutput = args[2];
+        if (args.length > 3) {
+            cdaOutput = args[3];
         }
 
 
@@ -39,13 +43,24 @@ public class EPrescriptionCdaGenerator {
 
         var prescriptionResponse = FmkResponseStorage.readStoredPrescriptions(prescriptionResponseFile.toFile());
         System.out.printf("Reading FMK prescription from %s%n", prescriptionResponseFile.toAbsolutePath());
+        var prescriptionIndex = 0;
+        if (prescriptionIdPath != null) {
+            var prescriptionId = Long.parseLong(Files.readString(Path.of(prescriptionIdPath), StandardCharsets.UTF_8));
+            var prescription = prescriptionResponse.getPrescription()
+                .stream()
+                .filter(p -> p.getIdentifier() == prescriptionId)
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException(
+                    String.format("Prescription with id %s not found in gotten prescriptions", prescriptionId)));
+            prescriptionIndex = prescriptionResponse.getPrescription().indexOf(prescription);
+        }
 
         var medicationResponse = FmkResponseStorage.readStoredMedication(medicationResponseFile.toFile());
         System.out.printf("Reading FMK medication from %s%n", medicationResponseFile.toAbsolutePath());
         var xmlString = EPrescriptionL3Generator.generate(
             new EPrescriptionL3Input(
                 prescriptionResponse,
-                0,
+                prescriptionIndex,
                 medicationResponse,
                 "FIN", // Fyldt injektionssprøjte
                 1,

--- a/national-connector/testing-tools/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/script/FmkPrescriptionCreator.java
+++ b/national-connector/testing-tools/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/script/FmkPrescriptionCreator.java
@@ -34,6 +34,9 @@ import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.math.BigDecimal;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -329,6 +332,21 @@ public class FmkPrescriptionCreator {
             input = args[0];
         }
 
-        createNewPrecriptionForCpr(input);
+        var outputPath = "target/test-files/prescription-id.txt";
+        if (args.length > 1) {
+            outputPath = args[1];
+        }
+
+        var resp = createNewPrecriptionForCpr(input);
+        var prescriptionId = resp.getPrescription().getFirst().getPrescriptionIdentifier().getFirst();
+        var path = Path.of(outputPath);
+        Files.createDirectories(path.getParent());
+        Files.writeString(
+            path.toAbsolutePath(),
+            prescriptionId.toString(),
+            StandardOpenOption.CREATE,
+            StandardOpenOption.TRUNCATE_EXISTING);
+
+        System.out.printf("Wrote %s to %s", prescriptionId, path);
     }
 }


### PR DESCRIPTION
The dispensation test created a new prescription with FMK and then proceeded to always take the top prescription. Since the current top prescription is locked, this doesn't work. Now, it passes the id of the created prescription to the next steps.