### PR TITLE
fix error and log when LMS is too short

### DIFF
--- a/national-connector/epps-application/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/Controller.java
+++ b/national-connector/epps-application/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/Controller.java
@@ -99,7 +99,7 @@ public class Controller {
 
     /// There is only one patient summary per patient, but the MyHealth@EU api functions like a document repository, so
     /// we have to let them search for that one document. We could also have returned it directly in the NCP adapter,
-    /// but we want all the business logic in this application.
+    /// but we want all the business logic in national connector.
     @PostMapping(path = "/api/find-patient-summary-document/")
     public DocumentAssociationForPatientSummaryDocumentMetadataDto findPatientSummaryDocument(
         @Valid @RequestBody FindDocumentsRequestDto params

--- a/national-connector/local-lms-db/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/locallms/Specs.java
+++ b/national-connector/local-lms-db/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/locallms/Specs.java
@@ -1,8 +1,11 @@
 package dk.sundhedsdatastyrelsen.ncpeh.locallms;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class Specs {
     private Specs() {
     }
@@ -33,10 +36,17 @@ public class Specs {
     ) {
         public List<String> parseRow(String row) {
             return fields().stream()
-                .map(field -> row.substring(
-                        field.startColumn,
-                        Math.min(row.length(), field.startColumn() + field.size()))
-                    .trim())
+                .map(field -> {
+                    // TODO temporary logging to understand why this sometimes happens.
+                    if (row.length() < field.startColumn) {
+                        log.warn("Row shorter than start column. startColumn: {}. Row: {}.", field.startColumn(), row);
+                        return "";
+                    }
+                    return row.substring(
+                            field.startColumn,
+                            Math.min(row.length(), field.startColumn() + field.size()))
+                        .trim();
+                })
                 .toList();
         }
 


### PR DESCRIPTION
In https://github.com/Sundhedsdatastyrelsen/ehdsi/actions/runs/21934336259/job/63345195619, we got the following error:

```
java.lang.StringIndexOutOfBoundsException: Range [126, 26) out of bounds for length 26
        ...
	at java.base/java.lang.String.substring(String.java:2823)
	at dk.sundhedsdatastyrelsen.ncpeh.locallms.Specs$Table.lambda$parseRow$0(Specs.java:36)
        ...
	at dk.sundhedsdatastyrelsen.ncpeh.locallms.Specs$Table.parseRow(Specs.java:40)
	at dk.sundhedsdatastyrelsen.ncpeh.locallms.LocalLmsLoader.parseAndLoadRawData(LocalLmsLoader.java:51)
	at dk.sundhedsdatastyrelsen.ncpeh.locallms.LocalLmsLoader.fetchData(LocalLmsLoader.java:26)
	at dk.sundhedsdatastyrelsen.ncpeh.FmkIT.initialiseLmsData(FmkIT.java:87)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```

This pr fixes that error, and logs the line from LMS that caused it, so we can understand what's going on.

LMS is a fixed length file format, so we should never see lines that are too short.