### PR TITLE
Rewrite NspClientDgws to be static

### DIFF
--- a/national-connector/.idea/.gitignore
+++ b/national-connector/.idea/.gitignore
@@ -6,3 +6,4 @@
 misc.xml
 uiDesigner.xml
 /sonarlint.xml
+remote-targets.xml

--- a/national-connector/epps-application/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/Beans.java
+++ b/national-connector/epps-application/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/Beans.java
@@ -7,6 +7,7 @@ import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.idcard.DgwsIdCardRequest;
 import dk.sundhedsdatastyrelsen.ncpeh.client.AuthorizationRegistryClient;
 import dk.sundhedsdatastyrelsen.ncpeh.client.CprClient;
+import dk.sundhedsdatastyrelsen.ncpeh.client.FmkClientIdws;
 import dk.sundhedsdatastyrelsen.ncpeh.client.FskClient;
 import dk.sundhedsdatastyrelsen.ncpeh.client.MinLogClient;
 import dk.sundhedsdatastyrelsen.ncpeh.client.NspClientDgws;
@@ -79,16 +80,14 @@ public class Beans {
 
     @Bean
     public PrescriptionService prescriptionService(
-        @Value("${app.fmk.endpoint.url}") String fmkEndpointUrl,
-        SigningCertificate signingCertificate,
+        FmkClientIdws fmkClient,
         UndoDispensationRepository undoDispensationRepository,
         @Qualifier("localLmsDataSource") DataSource lmsDataSource,
         AuthorizationRegistryClient authorizationRegistry,
         NspDgwsIdentity.System systemIdentity
     ) {
         return new PrescriptionService(
-            fmkEndpointUrl,
-            signingCertificate,
+            fmkClient,
             undoDispensationRepository,
             lmsDataSource,
             authorizationRegistry,
@@ -119,13 +118,27 @@ public class Beans {
         @Qualifier("jobQueueDataSource") DataSource jobQueueDataSource,
         @Value("${app.minlog.max-attempts:3}") int maxAttempts,
         @Value("${app.minlog.endpoint.url}") String minlogEndpointUrl,
+        FmkClientIdws fmkClient,
         NspClientDgws nspClientDgws
     ) throws JAXBException, URISyntaxException, SQLException {
         var minLogClient = new MinLogClient(minlogEndpointUrl, nspClientDgws);
         var fskClient = new FskClient(fskEndpointUrl, nspClientDgws);
         var minLogService = new MinLogService(minLogClient, systemCaller, jobQueueDataSource, maxAttempts);
         var informationCardService = new InformationCardService(fskClient, minLogService, systemCaller);
-        return new PatientSummaryService(informationCardService);
+        return new PatientSummaryService(informationCardService, fmkClient);
+    }
+
+    @Bean
+    public FmkClientIdws fmkClient (
+        SigningCertificate signingCertificate,
+        @Value("${app.fmk.endpoint.url}") String fmkEndpointUrl
+    )
+    {
+        try {
+            return new FmkClientIdws(signingCertificate.getCertificateAndKey().privateKey(), fmkEndpointUrl);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Malformed FMK endpoint", e);
+        }
     }
 
     @Bean

--- a/national-connector/epps-application/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/Beans.java
+++ b/national-connector/epps-application/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/Beans.java
@@ -106,9 +106,9 @@ public class Beans {
     @Bean
     public AuthorizationRegistryClient authorizationRegistryClient(
         @Value("${app.authorization-registry.endpoint.url}") String serviceUri,
-        NspClientDgws nspClientDgws
+        AuthenticationService authenticationService
     ) {
-        return new AuthorizationRegistryClient(serviceUri, nspClientDgws);
+        return new AuthorizationRegistryClient(serviceUri, authenticationService);
     }
 
     @Bean
@@ -119,21 +119,20 @@ public class Beans {
         @Value("${app.minlog.max-attempts:3}") int maxAttempts,
         @Value("${app.minlog.endpoint.url}") String minlogEndpointUrl,
         FmkClientIdws fmkClient,
-        NspClientDgws nspClientDgws
+        AuthenticationService authenticationService
     ) throws JAXBException, URISyntaxException, SQLException {
-        var minLogClient = new MinLogClient(minlogEndpointUrl, nspClientDgws);
-        var fskClient = new FskClient(fskEndpointUrl, nspClientDgws);
+        var minLogClient = new MinLogClient(minlogEndpointUrl, authenticationService);
+        var fskClient = new FskClient(fskEndpointUrl, authenticationService);
         var minLogService = new MinLogService(minLogClient, systemCaller, jobQueueDataSource, maxAttempts);
         var informationCardService = new InformationCardService(fskClient, minLogService, systemCaller);
         return new PatientSummaryService(informationCardService, fmkClient);
     }
 
     @Bean
-    public FmkClientIdws fmkClient (
+    public FmkClientIdws fmkClient(
         SigningCertificate signingCertificate,
         @Value("${app.fmk.endpoint.url}") String fmkEndpointUrl
-    )
-    {
+    ) {
         try {
             return new FmkClientIdws(signingCertificate.getCertificateAndKey().privateKey(), fmkEndpointUrl);
         } catch (URISyntaxException e) {
@@ -145,9 +144,9 @@ public class Beans {
     public CprService cprService(
         NspDgwsIdentity.System systemCaller,
         @Value("${app.cpr.endpoint.url}") String serviceUri,
-        NspClientDgws nspClientDgws
+        AuthenticationService authenticationService
     ) throws JAXBException, URISyntaxException {
-        var cprClient = new CprClient(serviceUri, nspClientDgws);
+        var cprClient = new CprClient(serviceUri, authenticationService);
         return new CprService(cprClient, systemCaller);
     }
 
@@ -170,8 +169,4 @@ public class Beans {
             idwsConfig.issuer());
     }
 
-    @Bean
-    public NspClientDgws nspClientDgws(AuthenticationService authenticationService) {
-        return new NspClientDgws(authenticationService);
-    }
 }

--- a/national-connector/epps-application/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/Beans.java
+++ b/national-connector/epps-application/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/Beans.java
@@ -10,7 +10,6 @@ import dk.sundhedsdatastyrelsen.ncpeh.client.CprClient;
 import dk.sundhedsdatastyrelsen.ncpeh.client.FmkClientIdws;
 import dk.sundhedsdatastyrelsen.ncpeh.client.FskClient;
 import dk.sundhedsdatastyrelsen.ncpeh.client.MinLogClient;
-import dk.sundhedsdatastyrelsen.ncpeh.client.NspClientDgws;
 import dk.sundhedsdatastyrelsen.ncpeh.config.AuthenticationServiceConfig;
 import dk.sundhedsdatastyrelsen.ncpeh.service.CprService;
 import dk.sundhedsdatastyrelsen.ncpeh.service.InformationCardService;

--- a/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PatientSummaryService.java
+++ b/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PatientSummaryService.java
@@ -1,5 +1,6 @@
 package dk.sundhedsdatastyrelsen.ncpeh.service;
 
+import dk.dkma.medicinecard.xml_schema._2015._06._01.FMKConfigurationListType;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.PublicException;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XmlException;
@@ -9,6 +10,7 @@ import dk.sundhedsdatastyrelsen.ncpeh.cda.DocumentIdMapper;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.PatientSummaryInput;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.PatientSummaryL1Generator;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.PatientSummaryL3Generator;
+import dk.sundhedsdatastyrelsen.ncpeh.client.FmkClientIdws;
 import dk.sundhedsdatastyrelsen.ncpeh.ncp.api.ClassCodeDto;
 import dk.sundhedsdatastyrelsen.ncpeh.ncp.api.ConfidentialityMetadataDto;
 import dk.sundhedsdatastyrelsen.ncpeh.ncp.api.DocumentAssociationForPatientSummaryDocumentMetadataDto;
@@ -26,9 +28,11 @@ import java.util.UUID;
 @Slf4j
 public class PatientSummaryService {
     private final InformationCardService informationCardService;
+    private final FmkClientIdws fmkService;
 
-    public PatientSummaryService(InformationCardService informationCardService) {
+    public PatientSummaryService(InformationCardService informationCardService, FmkClientIdws fmkService) {
         this.informationCardService = informationCardService;
+        this.fmkService = fmkService;
     }
 
     @WithSpan

--- a/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PatientSummaryService.java
+++ b/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PatientSummaryService.java
@@ -1,6 +1,5 @@
 package dk.sundhedsdatastyrelsen.ncpeh.service;
 
-import dk.dkma.medicinecard.xml_schema._2015._06._01.FMKConfigurationListType;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.PublicException;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XmlException;

--- a/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PrescriptionService.java
+++ b/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PrescriptionService.java
@@ -72,19 +72,14 @@ public class PrescriptionService {
     private final NspDgwsIdentity.System systemIdentity;
 
     public PrescriptionService(
-        String fmkEndpointUrl,
-        SigningCertificate signingCertificate,
+        FmkClientIdws fmkClient,
         UndoDispensationRepository undoDispensationRepository,
         DataSource lmsDataSource,
         AuthorizationRegistryClient authorizationRegistry,
         NspDgwsIdentity.System systemIdentity
     ) {
         this.systemIdentity = systemIdentity;
-        try {
-            this.fmkClient = new FmkClientIdws(signingCertificate.getCertificateAndKey().privateKey(), fmkEndpointUrl);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("Malformed FMK endpoint", e);
-        }
+        this.fmkClient = fmkClient;
         this.undoDispensationRepository = undoDispensationRepository;
         this.lmsDataProvider = new DataProvider(lmsDataSource);
         this.authorizationRegistry = authorizationRegistry;

--- a/national-connector/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/AuthorizationRegistryIT.java
+++ b/national-connector/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/AuthorizationRegistryIT.java
@@ -14,7 +14,7 @@ class AuthorizationRegistryIT {
 
     @Test
     void authorizationLookup() throws JAXBException {
-        var client = new AuthorizationRegistryClient(serviceUrl, Sosi.nspClientDgws);
+        var client = new AuthorizationRegistryClient(serviceUrl, Sosi.authenticationService);
         // 6QF17 is the authorisation code of Charles Babbage
         var response = client.requestByAuthorizationCode("6QF17", TestIdentities.systemIdentity);
 

--- a/national-connector/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/FmkIT.java
+++ b/national-connector/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/FmkIT.java
@@ -7,6 +7,7 @@ import dk.dkma.medicinecard.xml_schema._2015._06._01.e6.PrescriptionType;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XmlUtils;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.Oid;
 import dk.sundhedsdatastyrelsen.ncpeh.client.AuthorizationRegistryClient;
+import dk.sundhedsdatastyrelsen.ncpeh.client.FmkClientIdws;
 import dk.sundhedsdatastyrelsen.ncpeh.locallms.DataProvider;
 import dk.sundhedsdatastyrelsen.ncpeh.locallms.FtpConnection;
 import dk.sundhedsdatastyrelsen.ncpeh.locallms.LocalLmsLoader;
@@ -28,6 +29,7 @@ import org.w3c.dom.Document;
 
 import javax.sql.DataSource;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
@@ -50,13 +52,19 @@ class FmkIT {
     }
 
     private static PrescriptionService prescriptionService(DataSource lmsDataSource) {
-        return new PrescriptionService(
-            Fmk.FMK_IDWS_ENDPOINT_URI,
-            new SigningCertificate(Fmk.getSigningKey()),
-            undoDispensationRepository(),
-            lmsDataSource,
-            authorizationRegistryClient(),
-            TestIdentities.systemIdentity);
+        try {
+            var fmkClient = new FmkClientIdws(
+                new SigningCertificate(Fmk.getSigningKey()).getCertificateAndKey()
+                    .privateKey(), Fmk.FMK_IDWS_ENDPOINT_URI);
+            return new PrescriptionService(
+                fmkClient,
+                undoDispensationRepository(),
+                lmsDataSource,
+                authorizationRegistryClient(),
+                TestIdentities.systemIdentity);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static FtpConnection.ServerInfo lmsServerInfo() {

--- a/national-connector/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/AuthorizationRegistryClient.java
+++ b/national-connector/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/AuthorizationRegistryClient.java
@@ -1,6 +1,7 @@
 package dk.sundhedsdatastyrelsen.ncpeh.client;
 
 import dk.nsi._2024._01._05.stamdataauthorization.AuthorizationResponseType;
+import dk.sundhedsdatastyrelsen.ncpeh.authentication.AuthenticationService;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
@@ -15,10 +16,10 @@ import java.net.URISyntaxException;
 public class AuthorizationRegistryClient {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(AuthorizationRegistryClient.class);
     private final URI serviceUri;
-    private final NspClientDgws nspClientDgws;
+    private final AuthenticationService authenticationService;
 
-    public AuthorizationRegistryClient(String serviceUri, NspClientDgws nspClientDgws) {
-        this.nspClientDgws = nspClientDgws;
+    public AuthorizationRegistryClient(String serviceUri, AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
         try {
             this.serviceUri = new URI(serviceUri);
         } catch (URISyntaxException e) {
@@ -43,11 +44,12 @@ public class AuthorizationRegistryClient {
         final Element response;
         try {
             log.info("Calling AuthorizationCodeService at {}", serviceUri);
-            response = nspClientDgws.request(
+            var assertion = authenticationService.nspDgwsIdentityToAssertion(caller);
+            response = NspClientDgws.request(
                 serviceUri,
                 authorizationCodeRequestType(authorizationCode),
                 "http://nsi.dk/sdm/Gateway",
-                caller
+                assertion
             );
         } catch (NspClientException | ParserConfigurationException e) {
             throw new NspClientException("AuthorizationCodeService request failed", e);

--- a/national-connector/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/CprClient.java
+++ b/national-connector/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/CprClient.java
@@ -1,5 +1,6 @@
 package dk.sundhedsdatastyrelsen.ncpeh.client;
 
+import dk.sundhedsdatastyrelsen.ncpeh.authentication.AuthenticationService;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
@@ -19,12 +20,12 @@ import java.net.URISyntaxException;
 public class CprClient {
 
     private final URI serviceUri;
-    private final NspClientDgws nspClientDgws;
+    private final AuthenticationService authenticationService;
     private final JAXBContext jaxbContext;
 
-    public CprClient(String serviceUri, NspClientDgws nspClientDgws) throws URISyntaxException, JAXBException {
+    public CprClient(String serviceUri, AuthenticationService authenticationService) throws URISyntaxException, JAXBException {
         this.serviceUri = new URI(serviceUri);
-        this.nspClientDgws = nspClientDgws;
+        this.authenticationService = authenticationService;
         jaxbContext = JAXBContext.newInstance(GetPersonInformationIn.class, GetPersonInformationOut.class);
     }
 
@@ -39,14 +40,16 @@ public class CprClient {
      */
     public GetPersonInformationOut getPersonInformation(String cpr, NspDgwsIdentity caller) throws JAXBException {
         final var requestBody = getPersonInformationIn(cpr);
+
         final Element response;
         try {
             log.info("Calling getPersonInformation at {}", serviceUri);
-            response = nspClientDgws.request(
+            var assertion = authenticationService.nspDgwsIdentityToAssertion(caller);
+            response = NspClientDgws.request(
                 serviceUri,
                 toElement(requestBody),
                 "http://rep.oio.dk/medcom.sundcom.dk/xml/wsdl/2007/06/28/getPersonInformation",
-                caller
+                assertion
             );
         } catch (NspClientException e) {
             throw new NspClientException("CPR registry request failed", e);

--- a/national-connector/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/FskClient.java
+++ b/national-connector/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/FskClient.java
@@ -1,5 +1,6 @@
 package dk.sundhedsdatastyrelsen.ncpeh.client;
 
+import dk.sundhedsdatastyrelsen.ncpeh.authentication.AuthenticationService;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import dk.sundhedsdatastyrelsen.ncpeh.client.utils.ClientUtils;
 import ihe.iti.xds_b._2007.ObjectFactory;
@@ -30,12 +31,12 @@ public class FskClient {
     private static final ihe.iti.xds_b._2007.ObjectFactory factory = new ObjectFactory();
 
     private final URI serviceUri;
-    private final NspClientDgws nspClientDgws;
+    private final AuthenticationService authenticationService;
     private final JAXBContext jaxbContext;
 
-    public FskClient(String fskEndpointUrl, NspClientDgws nspClientDgws) throws URISyntaxException, JAXBException {
+    public FskClient(String fskEndpointUrl, AuthenticationService authenticationService) throws URISyntaxException, JAXBException {
         this.serviceUri = new URI(fskEndpointUrl);
-        this.nspClientDgws = nspClientDgws;
+        this.authenticationService = authenticationService;
         this.jaxbContext = JAXBContext.newInstance(
             "ihe.iti.xds_b._2007"
                 + ":oasis.names.tc.ebxml_regrep.xsd.query._3"
@@ -90,11 +91,12 @@ public class FskClient {
         try {
             var fullUri = new URI(new StringBuilder().append(serviceUri).append(specificEndpoint).toString());
             log.info("Calling '{}' with a SOAP action '{}'", fullUri, soapAction);
-            reply = nspClientDgws.request(
+            var assertion = authenticationService.nspDgwsIdentityToAssertion(caller);
+            reply = NspClientDgws.request(
                 fullUri,
                 ClientUtils.toElement(jaxbContext, request),
                 soapAction,
-                caller
+                assertion
             );
         } catch (NspClientException | URISyntaxException e) {
             throw new NspClientException("FSK request failed", e);

--- a/national-connector/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/MinLogClient.java
+++ b/national-connector/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/MinLogClient.java
@@ -2,6 +2,7 @@ package dk.sundhedsdatastyrelsen.ncpeh.client;
 
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.RegistrationRequestType;
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.RegistrationResponseType;
+import dk.sundhedsdatastyrelsen.ncpeh.authentication.AuthenticationService;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import dk.sundhedsdatastyrelsen.ncpeh.client.utils.ClientUtils;
 import jakarta.xml.bind.JAXBContext;
@@ -20,10 +21,10 @@ public class MinLogClient {
 
     private final URI serviceUri;
     private final JAXBContext jaxbContext;
-    private final NspClientDgws nspClientDgws;
+    private final AuthenticationService authenticationService;
 
-    public MinLogClient(String minlogEndpointUrl, NspClientDgws nspClientDgws) {
-        this.nspClientDgws = nspClientDgws;
+    public MinLogClient(String minlogEndpointUrl, AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
         try {
             this.serviceUri = new URI(minlogEndpointUrl);
             this.jaxbContext = JAXBContext.newInstance(
@@ -60,11 +61,12 @@ public class MinLogClient {
         final Element reply;
         try {
             log.info("Calling '{}' with a SOAP action '{}'", serviceUri, soapAction);
-            reply = nspClientDgws.request(
+            var assertion = authenticationService.nspDgwsIdentityToAssertion(caller);
+            reply = NspClientDgws.request(
                 serviceUri,
                 ClientUtils.toElement(jaxbContext, request),
                 soapAction,
-                caller
+                assertion
             );
         } catch (NspClientException | JAXBException e) {
             throw new NspClientException("MinLog request failed", e);

--- a/national-connector/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/NspClientDgws.java
+++ b/national-connector/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/NspClientDgws.java
@@ -2,6 +2,7 @@ package dk.sundhedsdatastyrelsen.ncpeh.client;
 
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.AuthenticationException;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.AuthenticationService;
+import dk.sundhedsdatastyrelsen.ncpeh.authentication.DgwsAssertion;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XPathWrapper;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XmlException;
@@ -32,16 +33,14 @@ import java.util.regex.Pattern;
 public class NspClientDgws {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(NspClientDgws.class);
     private static final XPathWrapper xpath = new XPathWrapper(XmlNamespace.SOAP, XmlNamespace.WST);
-    private final AuthenticationService authenticationService;
 
-    public NspClientDgws(AuthenticationService authenticationService) {
-        this.authenticationService = authenticationService;
+    private NspClientDgws() {
     }
 
     /// Send a SOAP request to an NSP service.
-    public Element request(URI uri, Element soapBody, String soapAction, NspDgwsIdentity caller, Element... extraHeaders) {
+    public static Element request(URI uri, Element soapBody, String soapAction, DgwsAssertion idCard, Element... extraHeaders) {
         try {
-            var idCard = authenticationService.nspDgwsIdentityToAssertion(caller);
+
             var envelope = makeRequest(
                 soapBody, idCard.assertion(), Instant.now()
                     .truncatedTo(ChronoUnit.SECONDS), extraHeaders);

--- a/national-connector/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/NspClientDgws.java
+++ b/national-connector/nsp-client/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/client/NspClientDgws.java
@@ -1,9 +1,7 @@
 package dk.sundhedsdatastyrelsen.ncpeh.client;
 
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.AuthenticationException;
-import dk.sundhedsdatastyrelsen.ncpeh.authentication.AuthenticationService;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.DgwsAssertion;
-import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XPathWrapper;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XmlException;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XmlNamespace;

--- a/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Cpr.java
+++ b/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Cpr.java
@@ -1,5 +1,8 @@
 package dk.sundhedsdatastyrelsen.ncpeh.testing.shared;
 
+import dk.sundhedsdatastyrelsen.ncpeh.authentication.AuthenticationServiceCached;
+import dk.sundhedsdatastyrelsen.ncpeh.authentication.AuthenticationServiceImpl;
+import dk.sundhedsdatastyrelsen.ncpeh.authentication.idcard.DgwsIdCardRequest;
 import dk.sundhedsdatastyrelsen.ncpeh.client.CprClient;
 
 /**
@@ -14,7 +17,7 @@ public class Cpr {
     public static CprClient apiClient() {
         if (cprClient == null) {
             try {
-                cprClient = new CprClient(cprEndpointUri, Sosi.nspClientDgws);
+                cprClient = new CprClient(cprEndpointUri, Sosi.authenticationService);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Cpr.java
+++ b/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Cpr.java
@@ -1,8 +1,5 @@
 package dk.sundhedsdatastyrelsen.ncpeh.testing.shared;
 
-import dk.sundhedsdatastyrelsen.ncpeh.authentication.AuthenticationServiceCached;
-import dk.sundhedsdatastyrelsen.ncpeh.authentication.AuthenticationServiceImpl;
-import dk.sundhedsdatastyrelsen.ncpeh.authentication.idcard.DgwsIdCardRequest;
 import dk.sundhedsdatastyrelsen.ncpeh.client.CprClient;
 
 /**

--- a/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Fsk.java
+++ b/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Fsk.java
@@ -22,7 +22,7 @@ public class Fsk {
     public static FskClient apiClient() {
         if (fskClient == null) {
             try {
-                fskClient = new FskClient(fskEndpointUri, Sosi.nspClientDgws);
+                fskClient = new FskClient(fskEndpointUri, Sosi.authenticationService);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/MinLog.java
+++ b/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/MinLog.java
@@ -16,7 +16,7 @@ public class MinLog {
 
     public static MinLogClient apiClient() {
         if (minLogClient == null) {
-            minLogClient = new MinLogClient(MINLOG_ENDPOINT_URI, Sosi.nspClientDgws);
+            minLogClient = new MinLogClient(MINLOG_ENDPOINT_URI, Sosi.authenticationService);
         }
         return minLogClient;
     }

--- a/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Sosi.java
+++ b/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Sosi.java
@@ -106,7 +106,7 @@ public class Sosi {
         };
     }
 
-    public static final NspClientDgws nspClientDgws = new NspClientDgws(
+    public static final AuthenticationService authenticationService =
         new AuthenticationServiceCached(
             new AuthenticationServiceImpl(
                 null,
@@ -115,5 +115,5 @@ public class Sosi {
                     "NCPeH-DK",
                     "NCPeH-DK",
                     "Sundhedsdatastyrelsen")),
-            null));
+            null);
 }

--- a/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Sosi.java
+++ b/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Sosi.java
@@ -7,7 +7,6 @@ import dk.sundhedsdatastyrelsen.ncpeh.authentication.CertificateUtils;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpIdwsToken;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.idcard.DgwsIdCardRequest;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.test.TestUtils;
-import dk.sundhedsdatastyrelsen.ncpeh.client.NspClientDgws;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 

--- a/national-connector/testing-tools/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/script/FmkPrescriptionCreator.java
+++ b/national-connector/testing-tools/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/script/FmkPrescriptionCreator.java
@@ -20,6 +20,7 @@ import dk.sdsd.dgws._2010._08.PredefinedRequestedRole;
 import dk.sdsd.dgws._2012._06.ObjectFactory;
 import dk.sdsd.dgws._2012._06.WhitelistingHeader;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
+import dk.sundhedsdatastyrelsen.ncpeh.client.NspClientDgws;
 import dk.sundhedsdatastyrelsen.ncpeh.client.NspClientException;
 import dk.sundhedsdatastyrelsen.ncpeh.client.utils.ClientUtils;
 import dk.sundhedsdatastyrelsen.ncpeh.testing.shared.Fmk;
@@ -284,11 +285,12 @@ public class FmkPrescriptionCreator {
             extraHeaders = new Element[]{ClientUtils.toElement(jaxbContext, getWhitelistingHeader(requestedRole))};
         }
         try {
-            body = Sosi.nspClientDgws.request(
+            var assertion = Sosi.authenticationService.nspDgwsIdentityToAssertion(identity);
+            body = NspClientDgws.request(
                 URI.create(Fmk.FMK_DGWS_ENDPOINT_URI),
                 ClientUtils.toElement(jaxbContext, request),
                 soapAction,
-                identity,
+                assertion,
                 extraHeaders
             );
         } catch (Exception e) {


### PR DESCRIPTION
Refactored NspClientDgws to be static instead of non-static to streamline the NspClients. 
Which makes it possible to use Dgws to retrieve medicineCard.