### PR TITLE
fix substitution not allowed not working

### DIFF
--- a/national-connector/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
+++ b/national-connector/cda-generator/src/main/resources/templates/eprescription-cda-l3.ftlx
@@ -346,11 +346,7 @@
                             <entryRelationship inversionInd="true" typeCode="SUBJ">
                                 <observation classCode="OBS" moodCode="EVN">
                                     <code code="SUBST" codeSystem="2.16.840.1.113883.5.6" codeSystemName="ActClass" displayName="Substitution"/>
-                                    <#-- The following line gives a validation error:
-                                    org.xml.sax.SAXParseException; lineNumber: 161; columnNumber: 92; cvc-type.2: The type definition cannot be abstract for element value.
-                                    Therefore we leave it out for now.-->
-                                    <!--<value code="N" codeSystem="1.3.6.1.4.1.12559.11.10.1.3.1.42.7" codeSystemName="eHDSISubstitutionCode" displayName="none" />-->
-
+                                    <value code="N" codeSystem="2.16.840.1.113883.5.1070" xsi:type="CE" />
                                 </observation>
                             </entryRelationship>
 </#if>

--- a/national-connector/epps-service/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/service/DispensationAllowedTest.java
+++ b/national-connector/epps-service/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/service/DispensationAllowedTest.java
@@ -89,4 +89,12 @@ class DispensationAllowedTest {
         var res1 = DispensationAllowed.getDispensationRestrictions(prescription, pInfo);
         assertThat(res1, is("Dose dispensed medications are not supported."));
     }
+
+    @Test
+    void narcoticPrescriptionsAreBlocked() {
+        var prescription = PrescriptionType.builder().build();
+        var pInfo = new PackageInfo("", "AP4", "", 1);
+        var res1 = DispensationAllowed.getDispensationRestrictions(prescription, pInfo);
+        assertThat(res1, is("Medicine dispensation regulation prohibits cross border dispensation."));
+    }
 }


### PR DESCRIPTION
I realized that this was not working during the spring 2026 test. The description in art-decor is not specific enough. But with some good search-fu in the european commission's confluence, it now passes the validation.

https://webgate.ec.europa.eu/fpfis/wikis/spaces/EHDSI/pages/1368097443/2022-12-22+-+Semantic+Architecture+Workgroup

The test is contraband.