### PR TITLE
Delay "nightly" integration test job to 07:00 UTC

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,7 @@ name: Nightly integration test
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 04 * * *"
+    - cron: "00 07 * * *"
 
 env:
   # Several jobs, at least "Create a new prescription in FMK" and "Run integration tests", and probably more,


### PR DESCRIPTION
In an attempt to avoid service windows at FMK and DDV.