### PR TITLE
add the full text to parse-xml exceptions for better debugging

### DIFF
--- a/national-connector/base-utils/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/base/utils/XmlException.java
+++ b/national-connector/base-utils/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/base/utils/XmlException.java
@@ -1,6 +1,12 @@
 package dk.sundhedsdatastyrelsen.ncpeh.base.utils;
 
 public class XmlException extends RuntimeException {
+    private String fullText;
+
+    public String getFullText() {
+        return fullText;
+    }
+
     public XmlException(String message) {
         super(message);
     }
@@ -8,4 +14,10 @@ public class XmlException extends RuntimeException {
     public XmlException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    public XmlException(String message, Throwable cause, String fullText) {
+        this(message, cause);
+        this.fullText = fullText;
+    }
+
 }

--- a/national-connector/base-utils/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/base/utils/XmlUtils.java
+++ b/national-connector/base-utils/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/base/utils/XmlUtils.java
@@ -31,7 +31,11 @@ public class XmlUtils {
      * @throws XmlException if parsing fails
      */
     public static Document parse(String xml) {
-        return parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        try {
+            return parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        } catch (XmlException exc) {
+            throw new XmlException(exc.getMessage(), exc.getCause(), xml);
+        }
     }
 
     /**

--- a/national-connector/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/DdvIT.java
+++ b/national-connector/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/DdvIT.java
@@ -1,5 +1,6 @@
 package dk.sundhedsdatastyrelsen.ncpeh;
 
+import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XmlException;
 import dk.sundhedsdatastyrelsen.ncpeh.service.VaccinationService;
 import dk.sundhedsdatastyrelsen.ncpeh.testing.shared.Ddv;
 import dk.sundhedsdatastyrelsen.ncpeh.testing.shared.Fmk;
@@ -15,7 +16,12 @@ class DdvIT {
     @Test
     void getVaccinationTest() throws Exception {
         var token = Sosi.getToken(Sosi.Audience.DDV);
-        var vaccinations = vaccinationService.getVaccinationsForCpr(Fmk.cprKarl, token);
-        assertThat(vaccinations, is(not(empty())));
+        try {
+            var vaccinations = vaccinationService.getVaccinationsForCpr(Fmk.cprKarl, token);
+            assertThat(vaccinations, is(not(empty())));
+        } catch (XmlException xmlException) {
+            System.out.println(xmlException.getFullText() != null ? xmlException.getFullText() : "No full text in exception");
+            throw xmlException;
+        }
     }
 }


### PR DESCRIPTION
We are seeing errors some nights in our nightly tests with DDV, where the xml cannot be parsed, but we can't see what the actual content of the message was.

This will allow us to see that information. I've checked where we use the exception, and the data is not displayed to any users elsewhere. But it should still probably be removed again once we've identified the error, to make sure we don't log anything sensitive.