### PR TITLE
Revert "Delay "nightly" integration test job to 07:00 UTC (#447)"

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,7 @@ name: Nightly integration test
 on:
   workflow_dispatch:
   schedule:
-    - cron: "00 07 * * *"
+    - cron: "30 04 * * *"
 
 env:
   # Several jobs, at least "Create a new prescription in FMK" and "Run integration tests", and probably more,


### PR DESCRIPTION
This reverts commit 9370c0d1f31420535770be4e97c8f737b9082853.

We want to investigate what it actually is that fails with the debugging added in 14e7a8b98b4a9642f58a30ab0575b43cd4856d5b.