### PR TITLE
Blackbox monitoring

### DIFF
--- a/NCP/alloy/blackbox.yml
+++ b/NCP/alloy/blackbox.yml
@@ -5,3 +5,6 @@ modules:
     http:
       tls_config:
         insecure_skip_verify: true
+  tcp:
+    prober: tcp
+    timeout: 5s

--- a/NCP/alloy/blackbox.yml
+++ b/NCP/alloy/blackbox.yml
@@ -1,0 +1,7 @@
+modules:
+  http:
+    prober: http
+    timeout: 5s
+    http:
+      tls_config:
+        insecure_skip_verify: true

--- a/NCP/alloy/config.alloy
+++ b/NCP/alloy/config.alloy
@@ -253,9 +253,11 @@ prometheus.exporter.blackbox "integrations_blackbox" {
 discovery.relabel "blackbox_scrape_targets" {
   targets = prometheus.exporter.blackbox.integrations_blackbox.targets
 
-  // Override instance to be the probe URL rather than the component name
+  // Override instance to be "(env) url" rather than the component name
   rule {
-    source_labels = ["__param_target"]
+    source_labels = ["deployment_environment_name", "__param_target"]
+    regex         = "(.+);(.+)"
+    replacement   = "($1) $2"
     target_label  = "instance"
   }
 }

--- a/NCP/alloy/config.alloy
+++ b/NCP/alloy/config.alloy
@@ -195,3 +195,72 @@ otelcol.receiver.prometheus "edge" {
     metrics = [otelcol.processor.batch.default.input]
   }
 }
+
+
+/// Blackbox probing via Docker label discovery
+
+discovery.relabel "blackbox_targets" {
+  targets = discovery.docker.local.targets
+
+  // Only probe containers that have the label: monitoring.blackbox.url=<url>
+  rule {
+    source_labels = ["__meta_docker_container_label_monitoring_blackbox_url"]
+    regex         = "(.+)"
+    action        = "keep"
+  }
+
+  // Use container name as the probe name
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "name"
+    replacement   = "$1"
+  }
+
+  // Set address (URL to probe) from docker label
+  rule {
+    source_labels = ["__meta_docker_container_label_monitoring_blackbox_url"]
+    target_label  = "address"
+  }
+
+  // Set module; default to http, override with monitoring.blackbox.module
+  rule {
+    target_label = "module"
+    replacement  = "http"
+  }
+  rule {
+    source_labels = ["__meta_docker_container_label_monitoring_blackbox_module"]
+    regex         = "(.+)"
+    target_label  = "module"
+  }
+
+  // Carry over deployment_environment_name (default: unknown)
+  rule {
+    target_label = "deployment_environment_name"
+    replacement = "unknown"
+  }
+  rule {
+    source_labels = ["__meta_docker_container_label_monitoring_environment"]
+    target_label  = "deployment_environment_name"
+  }
+}
+
+prometheus.exporter.blackbox "integrations_blackbox" {
+  config_file = "/etc/alloy/blackbox.yml"
+  targets     = discovery.relabel.blackbox_targets.output
+}
+
+discovery.relabel "blackbox_scrape_targets" {
+  targets = prometheus.exporter.blackbox.integrations_blackbox.targets
+
+  // Override instance to be the probe URL rather than the component name
+  rule {
+    source_labels = ["__param_target"]
+    target_label  = "instance"
+  }
+}
+
+prometheus.scrape "blackbox" {
+  targets    = discovery.relabel.blackbox_scrape_targets.output
+  forward_to = [otelcol.receiver.prometheus.edge.receiver]
+}

--- a/NCP/docker-compose.yml
+++ b/NCP/docker-compose.yml
@@ -174,6 +174,9 @@ services:
       - tls_truststore_password
       - db_username
       - db_password
+    labels:
+      monitoring.blackbox.url: http://openncp-server:8090/openncp-ws-server/
+      monitoring.environment: ${GRAFANA_ENVIRONMENT:-Training}
 
   tomcat_node_b:
     build:

--- a/NCP/docker-compose.yml
+++ b/NCP/docker-compose.yml
@@ -30,9 +30,12 @@ secrets:
   tls_truststore_password:
     file: tls_truststore_password.txt
 
-x-monitoring-labels: &monitoring-labels
-  monitoring.logs.scrape: "true"
+x-common-labels: &common-labels
   monitoring.environment: ${GRAFANA_ENVIRONMENT:-Training}
+
+x-monitoring-labels: &log-scraping
+  <<: *common-labels
+  monitoring.logs.scrape: "true"
 
 # OpenTelemetry configuration as a YAML anchor for merging into service configurations
 x-opentelemetry-config: &opentelemetry-config
@@ -48,7 +51,7 @@ services:
     image: busybox
     user: root
     labels:
-      <<: *monitoring-labels
+      <<: *log-scraping
     entrypoint:
       - "chown"
       - "-R"
@@ -63,7 +66,9 @@ services:
     hostname: ${DB_HOST}
     image: mysql:9
     labels:
-      <<: *monitoring-labels
+      <<: *log-scraping
+      monitoring.blackbox.url: "openncp_db:3306"
+      monitoring.blackbox.module: "tcp"
     ports:
       - ${DB_EXPOSED_PORT}:${DB_INTERNAL_PORT}
     volumes:
@@ -96,7 +101,7 @@ services:
     container_name: "tsam-exporter"
     image: ghcr.io/sundhedsdatastyrelsen/ehdsi/dk-ncp-tsam-exporter:${IMAGE_TAG}
     labels:
-      <<: *monitoring-labels
+      <<: *log-scraping
     env_file: .env
     environment:
       DB_USER_FILE: /run/secrets/db_username
@@ -119,7 +124,7 @@ services:
     image: ghcr.io/sundhedsdatastyrelsen/ehdsi/dk-ncp-tsam-synchronizer:${IMAGE_TAG}
     profiles: ["initialization"] # prevents service from starting on `docker compose up`
     labels:
-      <<: *monitoring-labels
+      <<: *log-scraping
     build:
       target: "tsam-synchronizer"
     env_file: .env
@@ -175,8 +180,8 @@ services:
       - db_username
       - db_password
     labels:
+      <<: *common-labels
       monitoring.blackbox.url: http://openncp-server:8090/openncp-ws-server/
-      monitoring.environment: ${GRAFANA_ENVIRONMENT:-Training}
 
   tomcat_node_b:
     build:
@@ -218,6 +223,9 @@ services:
       - tls_truststore_password
       - db_username
       - db_password
+    labels:
+      <<: *common-labels
+      monitoring.blackbox.url: http://openncp-client:8091/openncp-client-connector/
 
   openncp-openatna:
     container_name: openncp-openatna
@@ -258,6 +266,9 @@ services:
       - tls_truststore_password
       - db_username
       - db_password
+    labels:
+      <<: *common-labels
+      monitoring.blackbox.url: http://openncp-openatna:8084/openatna-web/
 
   openncp-trc-sts:
     container_name: openncp-trc-sts
@@ -297,6 +308,9 @@ services:
       - tls_truststore_password
       - db_username
       - db_password
+    labels:
+      <<: *common-labels
+      monitoring.blackbox.url: http://openncp-trc-sts:8095/TRC-STS/
 
   openncp-translations-and-mappings:
     container_name: openncp-translations-and-mappings
@@ -336,6 +350,9 @@ services:
       - tls_truststore_password
       - db_username
       - db_password
+    labels:
+      <<: *common-labels
+      monitoring.blackbox.url: http://openncp-translations-and-mappings:8096/translations-and-mappings-ws/
 
   openncp-web-manager:
     container_name: openncp-web-manager
@@ -377,6 +394,9 @@ services:
       - tls_truststore_password
       - db_username
       - db_password
+    labels:
+      <<: *common-labels
+      monitoring.blackbox.url: http://openncp-web-manager:8097/openncp-gateway-backend/
 
   configuration-synchronizer:
     build:
@@ -385,7 +405,7 @@ services:
     image: ghcr.io/sundhedsdatastyrelsen/ehdsi/dk-ncp-configuration-utility:${IMAGE_TAG}
     restart: unless-stopped
     labels:
-      <<: *monitoring-labels
+      <<: *log-scraping
     env_file: .env
     volumes:
       - ./openncp-configuration.properties:/opt/openncp-configuration/openncp-configuration.properties:ro

--- a/NCP/docker-compose.yml
+++ b/NCP/docker-compose.yml
@@ -409,9 +409,12 @@ services:
   alloy-edge:
     image: grafana/alloy:v1.12.2
     restart: unless-stopped
-    command: ["run", "/etc/alloy/config.alloy", "--stability.level=experimental"]
+    ports:
+      - "12345:12345"
+    command: ["run", "--server.http.listen-addr=0.0.0.0:12345", "/etc/alloy/config.alloy", "--stability.level=experimental"]
     volumes:
       - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - ./alloy/blackbox.yml:/etc/alloy/blackbox.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
       OTLP_SERVER_ENDPOINT: http://host.docker.internal:4317

--- a/national-connector/docker-compose.yml
+++ b/national-connector/docker-compose.yml
@@ -40,7 +40,6 @@ services:
       OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
       OTEL_RESOURCE_ATTRIBUTES: "service.version=${VERSION:-latest},deployment.environment.name=${GRAFANA_ENVIRONMENT:-Training}"
       OTEL_TRACES_SAMPLER: "always_on"
-      OTEL_JMX_TARGET_SYSTEM: "tomcat"
     volumes:
       - ./config:/app/config:ro
       - ./data:/app/data

--- a/national-connector/docker-compose.yml
+++ b/national-connector/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
       OTEL_RESOURCE_ATTRIBUTES: "service.version=${VERSION:-latest},deployment.environment.name=${GRAFANA_ENVIRONMENT:-Training}"
       OTEL_TRACES_SAMPLER: "always_on"
+      OTEL_JMX_TARGET_SYSTEM: "tomcat"
     volumes:
       - ./config:/app/config:ro
       - ./data:/app/data
@@ -51,3 +52,6 @@ services:
       - ./secrets/LMSFTP_PASSWORD:/run/secrets/lmsftp/password:ro
     networks:
       - epps-backend
+    labels:
+      monitoring.blackbox.url: https://national-connector:4443/actuator/health
+      monitoring.environment: ${GRAFANA_ENVIRONMENT:-Training}


### PR DESCRIPTION
This PR introduces **blackbox monitoring** via the [Prometheus blackbox-exporter](https://github.com/prometheus/blackbox_exporter).

Blackbox monitoring works by probing a given URL at intervals. The probe results are exported as Prometheus metrics and sent to Mimir so we can use them for dashboards and alerting.

Probes are defined by docker labels.

Example dashboard view:

<img width="1833" height="1211" alt="image" src="https://github.com/user-attachments/assets/3e2a1e31-8452-4dc9-8677-e8361e498cee" />

This is the default Prometheus Blackbox Exporter dashboard (id: 7587).