### PR TITLE
change cpr in xua header in tests in calls to ddv and fmk

### DIFF
--- a/national-connector/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/DdvIT.java
+++ b/national-connector/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/DdvIT.java
@@ -15,7 +15,11 @@ class DdvIT {
 
     @Test
     void getVaccinationTest() throws Exception {
-        var token = Sosi.getToken(Sosi.Audience.DDV);
+        var token = Sosi.getToken(Sosi.TokenArgs.builder()
+            .audience(Sosi.Audience.DDV)
+            .healthProfessionalRole("221")
+            .patientCpr(Fmk.cprKarl)
+            .build());
         try {
             var vaccinations = vaccinationService.getVaccinationsForCpr(Fmk.cprKarl, token);
             assertThat(vaccinations, is(not(empty())));

--- a/national-connector/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/End2EndIT.java
+++ b/national-connector/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/End2EndIT.java
@@ -96,7 +96,7 @@ class End2EndIT {
                     .withIncludeOpenPrescriptions()
                     .end()
                     .build(),
-                Sosi.getToken(Sosi.Audience.FMK));
+                Sosi.getToken(Sosi.Audience.FMK, cpr));
     }
 
     static String fetchOrCreatePrescriptionId(GetPrescriptionResponseType existingPrescriptions, String cpr) throws Exception {

--- a/national-connector/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/FmkIT.java
+++ b/national-connector/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/FmkIT.java
@@ -115,7 +115,7 @@ class FmkIT {
             .end()
             .build();
 
-        var token = Sosi.getToken(Sosi.Audience.FMK);
+        var token = Sosi.getToken(Sosi.Audience.FMK, cpr);
 
         var prescriptions = Fmk.idwsApiClient()
             .getPrescription(getPrescriptionRequest, token);
@@ -144,7 +144,7 @@ class FmkIT {
             .end()
             .build();
 
-        var token = Sosi.getToken(Sosi.Audience.FMK);
+        var token = Sosi.getToken(Sosi.Audience.FMK, Fmk.cprKarl);
 
         var prescriptions = Fmk.idwsApiClient()
             .getPrescription(getPrescriptionRequest, token);
@@ -172,7 +172,7 @@ class FmkIT {
             .getFirst());
         var eDispensation = dispensationCda(cpr, prescriptionId);
 
-        var token = Sosi.getToken(Sosi.Audience.FMK);
+        var token = Sosi.getToken(Sosi.Audience.FMK, Fmk.cprKarl);
 
         try {
             prescriptionService.submitDispensation(patientId(cpr), eDispensation, token, true);
@@ -228,7 +228,7 @@ class FmkIT {
             eDispensationPath.toFile(),
             is(aReadableFile()));
         var eDispensation = XmlUtils.parse(Files.newInputStream(eDispensationPath));
-        var token = Sosi.getToken(Sosi.Audience.FMK);
+        var token = Sosi.getToken(Sosi.Audience.FMK, Fmk.cprKarl);
 
         // shouldn't throw:
         prescriptionService.submitDispensation(
@@ -259,13 +259,19 @@ class FmkIT {
         var pharmacyWorkerDispensation = dispensationCda(cpr, prescriptionId, "3213", "Pharmaceutical technicians and assistants");
         assertThat(DispensationMapper.authorRole(pharmacyWorkerDispensation), is("Udenlandsk apoteksansat"));
         var otherHealthProfessionalDispensation = dispensationCda(cpr, prescriptionId, "221", "Medical Doctors");
-        var pharmacistToken = Sosi.getToken(Sosi.Audience.FMK, "2262", "John House");
+        var tokenArgs = Sosi.TokenArgs.builder()
+            .audience(Sosi.Audience.FMK)
+            .patientCpr(cpr)
+            .build();
+        var pharmacistToken = Sosi.getToken(
+            tokenArgs.withHealthProfessionalRole("2262").withHealthProfessionalName("John House"));
 
         assertDoesNotThrow(() ->
             prescriptionService.submitDispensation(patientId(cpr), pharmacistDispensation, pharmacistToken)
         );
 
-        var pharmacyWorkerToken = Sosi.getToken(Sosi.Audience.FMK, "3213", "Mark Twain");
+        var pharmacyWorkerToken = Sosi.getToken(
+            tokenArgs.withHealthProfessionalRole("3213").withHealthProfessionalName("Mark Twain"));
 
         assertDoesNotThrow(() ->
             prescriptionService.undoDispensation(patientId(cpr), pharmacistDispensation, pharmacyWorkerToken)
@@ -275,7 +281,8 @@ class FmkIT {
             prescriptionService.submitDispensation(patientId(cpr), pharmacyWorkerDispensation, pharmacyWorkerToken)
         );
 
-        var otherHealthProfessionalToken = Sosi.getToken(Sosi.Audience.FMK, "221", "Oscar Wilde");
+        var otherHealthProfessionalToken = Sosi.getToken(
+            tokenArgs.withHealthProfessionalRole("221").withHealthProfessionalName("Oscar Wilde"));
 
         assertDoesNotThrow(() ->
             prescriptionService.undoDispensation(patientId(cpr), pharmacyWorkerDispensation, otherHealthProfessionalToken)
@@ -302,8 +309,11 @@ class FmkIT {
                 .withIncludeEffectuations(false)
                 .withIncludePrescriptions(false)
                 .build(),
-            Sosi.getToken(Sosi.Audience.FMK, "221")
-        );
+            Sosi.getToken(Sosi.TokenArgs.builder()
+                .audience(Sosi.Audience.FMK)
+                .patientCpr(cpr)
+                .healthProfessionalRole("221")
+                .build()));
 
         assertThat(medicineCard, is(notNullValue()));
     }

--- a/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/FmkResponseStorage.java
+++ b/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/FmkResponseStorage.java
@@ -260,11 +260,11 @@ public class FmkResponseStorage {
      */
     public static void main(String[] args) throws Exception {
         var frs = new FmkResponseStorage(Fmk.idwsApiClient());
-        var token = Sosi.getToken(Sosi.Audience.FMK, "221");
 
         var dir = Files.createDirectories(
             Path.of("testing-shared", "src", "main", "resources", rawResponseDir));
         for (var cpr : rawResponseCprs) {
+            var token = Sosi.getToken(Sosi.Audience.FMK, cpr);
             var f = dir.resolve("get-prescription-" + cpr + ".xml").toFile();
             var prescriptions = frs.getPrescriptionResponse(cpr, token);
             serializeToFile(frs.createXmlFromPrescription(prescriptions), f);

--- a/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Sosi.java
+++ b/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Sosi.java
@@ -7,12 +7,17 @@ import dk.sundhedsdatastyrelsen.ncpeh.authentication.CertificateUtils;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpIdwsToken;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.idcard.DgwsIdCardRequest;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.test.TestUtils;
+import lombok.Builder;
+import lombok.NonNull;
 import lombok.SneakyThrows;
+import lombok.Value;
+import lombok.With;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.util.Base64;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 /// Only for use in tests.
@@ -30,16 +35,26 @@ public class Sosi {
         Audience DDV = () -> "https://ddv";
     }
 
-    public static EuropeanHcpIdwsToken getToken(Audience audience) {
-        return getToken(audience, "2262");
+    @Builder
+    @Value
+    @With
+    public static class TokenArgs {
+        @NonNull
+        Audience audience;
+        /// Defaults to "2262", the pharmacist role.
+        String healthProfessionalRole;
+        ///  Defaults to "John House".
+        String healthProfessionalName;
+        @NonNull
+        String patientCpr;
     }
 
-    public static EuropeanHcpIdwsToken getToken(Audience audience, String role) {
-        return getToken(audience, role, null);
+    public static EuropeanHcpIdwsToken getToken(Audience audience, String patientCpr) {
+        return getToken(TokenArgs.builder().audience(audience).patientCpr(patientCpr).build());
     }
 
     @SneakyThrows
-    public static EuropeanHcpIdwsToken getToken(Audience audience, String role, String name) {
+    public static EuropeanHcpIdwsToken getToken(TokenArgs tokenArgs) {
         if (authService == null) {
             var base64 = System.getenv("CERT_BASE_64");
             var alias = System.getenv("CERT_ALIAS");
@@ -63,9 +78,22 @@ public class Sosi {
         if (soapHeader == null) {
             soapHeader = TestUtils.slurp(TestUtils.resource("openncp_soap_header.xml"));
         }
-        var headerWithRoleChange = changeRoleInHeader(soapHeader, role);
-        var headerWithNameChange = name == null ? headerWithRoleChange : changeNameInHeader(headerWithRoleChange, name);
-        return authService.xcaSoapHeaderToIdwsToken(headerWithNameChange, audience.value());
+        var headerWithRoleChange = Optional.ofNullable(tokenArgs.getHealthProfessionalRole())
+            .map(r -> changeRoleInHeader(soapHeader, r))
+            .orElse(soapHeader);
+        var headerWithNameChange = Optional.ofNullable(tokenArgs.getHealthProfessionalName())
+            .map(n -> changeNameInHeader(headerWithRoleChange, n))
+            .orElse(headerWithRoleChange);
+        var headerWithPatientIdChange = changePatientIdInHeader(headerWithNameChange, tokenArgs.getPatientCpr());
+        return authService.xcaSoapHeaderToIdwsToken(headerWithPatientIdChange, tokenArgs.getAudience().value());
+    }
+
+    private static String changePatientIdInHeader(String soapHeader, String patientId) {
+        var patientIdPattern = Pattern.compile("<saml2:Attribute\\b[^>]*\\bName\\s*=\\s*\"urn:oasis:names:tc:xspa:1.0:subject:subject-id\"[^>]*>.*?\\d{10}\\^\\^\\^&amp;1\\.2\\.208\\.176\\.1\\.2&amp;ISO.*?</saml2:Attribute>");
+        var requestedPatientIdElement = String.format(
+            "<saml2:Attribute FriendlyName=\"XSPA Subject\" Name=\"urn:oasis:names:tc:xspa:1.0:subject:subject-id\" NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:uri\"><saml2:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"xsd:string\">%s^^^&amp;1.2.208.176.1.2&amp;ISO</saml2:AttributeValue></saml2:Attribute>",
+            patientId);
+        return patientIdPattern.matcher(soapHeader).replaceFirst(requestedPatientIdElement);
     }
 
     private static String changeNameInHeader(String soapHeader, String name) {

--- a/national-connector/testing-tools/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/script/FmkPrescriptionCollector.java
+++ b/national-connector/testing-tools/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/script/FmkPrescriptionCollector.java
@@ -26,7 +26,7 @@ public class FmkPrescriptionCollector {
             medicationOutput = args[2];
         }
 
-        var token = Sosi.getToken(Sosi.Audience.FMK);
+        var token = Sosi.getToken(Sosi.Audience.FMK, cprInput);
         var frs = new FmkResponseStorage(Fmk.idwsApiClient());
         var prescriptionResponse = frs.getPrescriptionResponse(cprInput, token);
         var prescriptionXml = frs.createXmlFromPrescription(prescriptionResponse);


### PR DESCRIPTION
This fixes an issue caused by introduction of a (reasonable) check by ddv, where they validate that the cpr in the header is the same as the cpr in the body.

The CPR is now required in Sosi.getToken, because we can't create the token without knowing what CPR it's for.

The CPR replacement and the health professional name replacement regexes are very similar, care must be taken not to break these.

This won't be an issue in actual calls, as the CPR there is read from the actual header.