### PR TITLE
Observability fix: Promote environment from resource attribute to label

### DIFF
--- a/monitoring/alloy/config.alloy
+++ b/monitoring/alloy/config.alloy
@@ -19,7 +19,7 @@ otelcol.receiver.otlp "default" {
 otelcol.processor.batch "default" {
   output {
     metrics = [otelcol.exporter.prometheus.default.input]
-    logs    = [otelcol.exporter.loki.default.input]
+    logs    = [otelcol.processor.attributes.loki_labels.input]
     traces  = [otelcol.exporter.otlp.tempo.input]
   }
 }
@@ -36,6 +36,20 @@ prometheus.remote_write "default" {
 }
 
 // Loki exporter
+otelcol.processor.attributes "loki_labels" {
+  // Promote resource attribute to labels so that we can search and filter on the environment.
+  // (fairly obscure config option documented here: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.loki/)
+  action {
+    key    = "loki.resource.labels"
+    action = "insert"
+    value  = "deployment.environment.name"
+  }
+
+  output {
+    logs = [otelcol.exporter.loki.default.input]
+  }
+}
+
 otelcol.exporter.loki "default" {
   forward_to = [loki.write.default.receiver]
 }
@@ -56,4 +70,3 @@ otelcol.exporter.otlp "tempo" {
     }
  }
 }
-

--- a/monitoring/alloy/config.alloy
+++ b/monitoring/alloy/config.alloy
@@ -18,13 +18,29 @@ otelcol.receiver.otlp "default" {
 // Intermediate step, collects batches of otel data before sending it downstream
 otelcol.processor.batch "default" {
   output {
-    metrics = [otelcol.exporter.prometheus.default.input]
+    metrics = [otelcol.processor.transform.default.input]
     logs    = [otelcol.processor.attributes.loki_labels.input]
     traces  = [otelcol.exporter.otlp.tempo.input]
   }
 }
 
 // Prometheus exporter
+
+// Promote environment resource attribute to Prometheus label
+// https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.prometheus/#create-prometheus-labels-from-otlp-resource-attributes
+
+otelcol.processor.transform "default" {
+  error_mode = "ignore"
+
+  statements {
+    metric = [`set(datapoint.attributes["deployment_environment_name"], resource.attributes["deployment.environment.name"])`]
+  }
+
+  output {
+    metrics = [otelcol.exporter.prometheus.default.input]
+  }
+}
+
 otelcol.exporter.prometheus "default" {
   forward_to = [prometheus.remote_write.default.receiver]
 }

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -112,7 +112,8 @@ services:
     restart: unless-stopped
     ports:
       - "4317:4317"   # OTLP/gRPC
-    command: ["run", "/etc/alloy/config.alloy"]
+      # - "12346:12345" # alloy UI
+    command: ["run", "--server.http.listen-addr=0.0.0.0:12345", "/etc/alloy/config.alloy"]
     volumes:
       - alloy_data:/var/lib/alloy
       - ./alloy/config.alloy:/etc/alloy/config.alloy:ro


### PR DESCRIPTION
We have successfully added `deployment.environment.name` to all our OTEL data. But mostly it is recorded as a "resource attribute" which doesn't automatically gets indexed for logs and metrics.  I.e., we can't filter on the environment value.

This PR promotes the value to an indexed label for logs and metrics.

For traces it is possible to filter on resource attributes so no action is necessary.