### PR TITLE
Improve null handling in ImmunizationMapper and CDA rendering

### DIFF
--- a/NCP/test-tool/templates/xca/retrieve/request-ps.xml
+++ b/NCP/test-tool/templates/xca/retrieve/request-ps.xml
@@ -12,7 +12,7 @@
     <xdsb:RetrieveDocumentSetRequest xmlns:xdsb="urn:ihe:iti:xds-b:2007">
       <xdsb:DocumentRequest>
         <xdsb:RepositoryUniqueId>1.2.208.176.7.2.987654321</xdsb:RepositoryUniqueId>
-        <xdsb:DocumentUniqueId>1.2.208.176.7.2.987654321^478299832581102L1</xdsb:DocumentUniqueId>
+        <xdsb:DocumentUniqueId>1.2.208.176.7.2.987654321^478299832581102L3</xdsb:DocumentUniqueId>
       </xdsb:DocumentRequest>
     </xdsb:RetrieveDocumentSetRequest>
   </env:Body>

--- a/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/ImmunizationMapper.java
+++ b/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/ImmunizationMapper.java
@@ -47,7 +47,7 @@ public class ImmunizationMapper {
             .orElse(null);
     }
 
-    public static CdaCode getAtcCode (SSIDrugType ssiDrug){
+    public static CdaCode getAtcCode(SSIDrugType ssiDrug) {
         return Optional.ofNullable(ssiDrug)
             .map(SSIDrugType::getATC)
             .filter(atc -> atc.getCode() != null && atc.getText() != null)

--- a/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/ImmunizationMapper.java
+++ b/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/ImmunizationMapper.java
@@ -1,12 +1,10 @@
 package dk.sundhedsdatastyrelsen.ncpeh.cda;
 
-import dk.dkma.medicinecard.xml_schema._2015._06._01.e2.DrugMedicationType;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.CdaId;
 import dk.vaccinationsregister.schemas._2013._12._01.AuthorisedHealthcareProfessionalType;
 import dk.vaccinationsregister.schemas._2013._12._01.CreatedType;
 import dk.vaccinationsregister.schemas._2013._12._01.DrugStrengthType;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.CdaCode;
-import dk.sundhedsdatastyrelsen.ncpeh.cda.model.Product;
 import dk.vaccinationsregister.schemas._2013._12._01.ModificatorType;
 import dk.vaccinationsregister.schemas._2013._12._01.OrganisationType;
 import dk.vaccinationsregister.schemas._2013._12._01.SSIDrugType;
@@ -26,46 +24,51 @@ public class ImmunizationMapper {
         );
     }
 
-    public static Product product(SSIDrugType ssiDrug) {
+    public static CdaCode getDrugId(SSIDrugType ssiDrug) {
+        return Optional.ofNullable(ssiDrug)
+            .map(SSIDrugType::getDrugIdentifier)
+            .map(id -> CdaCode.builder()
+                .codeSystem(Oid.DK_DDV_SSI_DRUG)
+                .code(String.valueOf(id))
+                .build())
+            .orElse(null);
+    }
 
-        if (ssiDrug == null || ssiDrug.getDrugName() == null) {
-            return null;
-        }
-        var drugId = ssiDrug.getDrugIdentifier();
-        var codedId = drugId != null ? CdaCode.builder()
-            .codeSystem(Oid.DK_DDV_SSI_DRUG)
-            .code(String.valueOf(drugId))
-            .build() : null;
+    public static String getDrugName(SSIDrugType ssiDrug) {
+        return Optional.ofNullable(ssiDrug)
+            .map(SSIDrugType::getDrugName)
+            .orElse(null);
+    }
 
-        var form = ssiDrug.getDrugForm();
-        if (form == null || form.getDrugFormCode() == null || form.getDrugFormText() == null) {
-            return null;
-        }
+    public static String getStrength(SSIDrugType ssiDrug) {
+        return Optional.ofNullable(ssiDrug)
+            .map(SSIDrugType::getDrugStrength)
+            .map(ImmunizationMapper::getSubstanceStrengthText)
+            .orElse(null);
+    }
 
-        var atc = ssiDrug.getATC();
-        if (atc == null || atc.getCode() == null || atc.getText() == null) {
-            return null;
-        }
+    public static CdaCode getAtcCode (SSIDrugType ssiDrug){
+        return Optional.ofNullable(ssiDrug)
+            .map(SSIDrugType::getATC)
+            .filter(atc -> atc.getCode() != null && atc.getText() != null)
+            .map(atc -> CdaCode.builder()
+                .codeSystem(Oid.ATC)
+                .code(atc.getCode())
+                .displayName(atc.getText())
+                .build())
+            .orElse(null);
+    }
 
-        var formCode = CdaCode.builder()
-            .codeSystem(Oid.DK_LMS22) //TODO: Check if this is the right code.
-            .code(form.getDrugFormCode())
-            .displayName(form.getDrugFormText())
-            .build();
-
-        var atcCode = CdaCode.builder()
-            .codeSystem(Oid.ATC)
-            .code(atc.getCode())
-            .displayName(atc.getText())
-            .build();
-
-        return Product.builder()
-            .drugId(codedId)
-            .name(ssiDrug.getDrugName())
-            .strength(getSubstanceStrengthText(ssiDrug.getDrugStrength()))
-            .formCode(formCode)
-            .atcCode(atcCode)
-            .build();
+    public static CdaCode getFormCode(SSIDrugType ssiDrug) {
+        return Optional.ofNullable(ssiDrug)
+            .map(SSIDrugType::getDrugForm)
+            .filter(form -> form.getDrugFormCode() != null && form.getDrugFormText() != null)
+            .map(form -> CdaCode.builder()
+                .codeSystem(Oid.DK_LMS22)
+                .code(form.getDrugFormCode())
+                .displayName(form.getDrugFormText())
+                .build())
+            .orElse(null);
     }
 
     private static String getSubstanceStrengthText(DrugStrengthType strength) {

--- a/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/PatientSummaryL3Mapper.java
+++ b/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/PatientSummaryL3Mapper.java
@@ -97,7 +97,6 @@ public class PatientSummaryL3Mapper {
 
         // Sort by vaccination identifier, then by vaccination plan identifier,
         // and finally by vaccination plan item index. For easier reading in the CDA
-
         return response.getVaccination().stream()
             .filter(Objects::nonNull)
             .filter(v -> v.isNegativeConsentIndicator() == null || !v.isNegativeConsentIndicator())

--- a/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/PatientSummaryL3Mapper.java
+++ b/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/PatientSummaryL3Mapper.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static dk.sundhedsdatastyrelsen.ncpeh.cda.ImmunizationMapper.fallbackVaccineName;
+import static dk.sundhedsdatastyrelsen.ncpeh.cda.ImmunizationMapper.immunizationId;
 
 @Slf4j
 public class PatientSummaryL3Mapper {
@@ -186,7 +187,6 @@ public class PatientSummaryL3Mapper {
         var planned = vaccination.getEffectuatedPlannedItem();
         var drug = vaccination.getSSIDrug();
         var vaccine = vaccination.getVaccine();
-        var product = ImmunizationMapper.product(drug);
 
         return ImmunizationItem.builder()
             .immunizationId(ImmunizationMapper.immunizationId(vaccination))
@@ -198,11 +198,11 @@ public class PatientSummaryL3Mapper {
             .targetDiseaseText(vaccine != null ? vaccine.getVaccineName() : null)
 
             // Product / consumable
-            .drugId(product.getDrugId())
-            .name(drug != null ? product.getName() : fallbackVaccineName(vaccination))
-            .strength(product.getStrength())
-            .formCode(product.getFormCode())
-            .atcCode(product.getAtcCode())
+            .drugId(ImmunizationMapper.getDrugId(drug))
+            .name(drug != null ? ImmunizationMapper.getDrugName(drug) : fallbackVaccineName(vaccination))
+            .strength(ImmunizationMapper.getStrength(drug))
+            .formCode(ImmunizationMapper.getFormCode(drug))
+            .atcCode(ImmunizationMapper.getAtcCode(drug))
 
             .doseNumber(Optional.ofNullable(planned)
                 .map(EffectuatedPlannedItemType::getVaccinationPlanItemIndex)
@@ -212,7 +212,6 @@ public class PatientSummaryL3Mapper {
             .coverageDuration(vaccination.getCoverageDuration())
             .vaccinationPlanName(planned != null ? planned.getVaccinationPlanName() : null)
             .vaccinationPlanItemDescription(planned != null ? planned.getVaccinationPlanItemDescription() : null)
-
             .healthProfessionalIdentifier(ImmunizationMapper.getCreatedAuthorisationId(vaccination))
             .healthProfessionalName(ImmunizationMapper.getCreatedAuthorName(vaccination))
             .administeringCentreIdentifier(ImmunizationMapper.getCreatedOrganisationId(vaccination))

--- a/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/PatientSummaryL3Mapper.java
+++ b/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/PatientSummaryL3Mapper.java
@@ -21,7 +21,6 @@ import dk.sundhedsdatastyrelsen.ncpeh.cda.model.PatientSummaryL3;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.Product;
 import dk.vaccinationsregister.schemas._2013._12._01.EffectuatedPlannedItemType;
 import dk.vaccinationsregister.schemas._2013._12._01.GetVaccinationCardResponseType;
-import dk.vaccinationsregister.schemas._2013._12._01.SSIDrugType;
 import dk.vaccinationsregister.schemas._2013._12._01.VaccinationType;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -32,9 +31,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static dk.sundhedsdatastyrelsen.ncpeh.cda.ImmunizationMapper.fallbackVaccineName;
-import static dk.sundhedsdatastyrelsen.ncpeh.cda.ImmunizationMapper.immunizationId;
 
 @Slf4j
 public class PatientSummaryL3Mapper {
@@ -198,7 +194,7 @@ public class PatientSummaryL3Mapper {
 
             // Product / consumable
             .drugId(ImmunizationMapper.getDrugId(drug))
-            .name(drug != null ? ImmunizationMapper.getDrugName(drug) : fallbackVaccineName(vaccination))
+            .name(drug != null ? ImmunizationMapper.getDrugName(drug) : ImmunizationMapper.fallbackVaccineName(vaccination))
             .strength(ImmunizationMapper.getStrength(drug))
             .formCode(ImmunizationMapper.getFormCode(drug))
             .atcCode(ImmunizationMapper.getAtcCode(drug))

--- a/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Immunizations.java
+++ b/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Immunizations.java
@@ -50,10 +50,10 @@ public class Immunizations {
          * hl7:consumable / eHDSI Immunization SSIDrug.
          */
         CdaCode drugId;
-        @NonNull String name;
+        String name;
         String strength;
-        @NonNull CdaCode formCode;
-        @NonNull CdaCode atcCode;
+        CdaCode formCode;
+        CdaCode atcCode;
 
         /**
          * hl7:entryRelationship Dose Number.

--- a/national-connector/cda-generator/src/main/resources/templates/patient-summary-cda-l3.ftlx
+++ b/national-connector/cda-generator/src/main/resources/templates/patient-summary-cda-l3.ftlx
@@ -498,13 +498,15 @@
                     <list>
                     <#list immunizations.items as imm>
                         <item ID="immunization-${imm?index}">
-                            <content ID="immunization-name-${imm?index}">${imm.name}</content><br/>
-                            <#if imm.vaccinationDate?has_content>
+                            <content ID="immunization-name-${imm?index}">
+                                <#if imm.name?has_content>${imm.name}</#if>
+                            </content><br/>
+                            <#if (imm.vaccinationDate)?has_content>
                             <content ID="immunization-date-${imm?index}">${imm.vaccinationDate}</content><br/>
                             </#if>
-                            <#if imm.vaccinationPlanName?has_content>
+                            <#if (imm.vaccinationPlanName)?has_content>
                             <content ID="immunization-plan-${imm?index}">
-                                ${imm.vaccinationPlanName}<#if imm.vaccinationPlanItemDescription?has_content> - ${imm.vaccinationPlanItemDescription}</#if>
+                                ${imm.vaccinationPlanName}<#if (imm.vaccinationPlanItemDescription)?has_content> - ${imm.vaccinationPlanItemDescription}</#if>
                             </content><br/>
                             </#if>
                             <paragraph>Data source: DDV 1.4.0</paragraph>
@@ -537,16 +539,33 @@
                                 <manufacturedProduct classCode="MANU">
                                     <templateId root="1.3.6.1.4.1.12559.11.10.1.3.1.3.18"/>
                                     <manufacturedMaterial classCode="MMAT" determinerCode="KIND">
+                                        <#if imm.atcCode??>
                                         <code <@common.cdaCodeAttrs imm.atcCode />>
                                             <originalText>
                                                 <reference value="#immunization-name-${imm?index}"/>
                                             </originalText>
                                         </code>
+                                        <#else>
+                                        <code nullFlavor="UNK">
+                                            <originalText>
+                                                <reference value="#immunization-name-${imm?index}"/>
+                                            </originalText>
+                                        </code>
+                                        </#if>
+                                        <#if (imm.name)?has_content>
                                         <name>${imm.name}</name>
+                                        </#if>
+
                                         <#if (imm.strength)?has_content>
                                         <pharm:desc>${imm.strength}</pharm:desc>
                                         </#if>
+
+                                        <#if imm.formCode??>
                                         <pharm:formCode <@common.cdaCodeAttrs imm.formCode />/>
+                                        <#else>
+                                        <pharm:formCode nullFlavor="UNK"/>
+                                        </#if>
+
                                         <#if (imm.batchNumber)?has_content>
                                         <lotNumberText>${imm.batchNumber}</lotNumberText>
                                         </#if>

--- a/national-connector/cda-generator/src/main/resources/templates/patient-summary-cda-l3.ftlx
+++ b/national-connector/cda-generator/src/main/resources/templates/patient-summary-cda-l3.ftlx
@@ -538,6 +538,8 @@
                             <consumable typeCode="CSM">
                                 <manufacturedProduct classCode="MANU">
                                     <templateId root="1.3.6.1.4.1.12559.11.10.1.3.1.3.18"/>
+                                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.1.53"/>
                                     <manufacturedMaterial classCode="MMAT" determinerCode="KIND">
                                         <#if imm.atcCode??>
                                         <code <@common.cdaCodeAttrs imm.atcCode />>
@@ -585,7 +587,8 @@
                                 </observation>
                             </entryRelationship>
                             </#if>
-                            <#if imm.targetDiseaseCode?? || imm.targetDiseaseText?has_content>
+                            <#if false>
+                            <#-- DK does not have information on adverse reactions to the vaccination. -->
                             <entryRelationship inversionInd="false" typeCode="CAUS">
                                 <observation classCode="OBS" moodCode="EVN">
                                     <templateId root="1.3.6.1.4.1.12559.11.10.1.3.1.3.7"/>
@@ -638,7 +641,7 @@
                         <procedure classCode="PROC" moodCode="EVN">
                             <templateId root="1.3.6.1.4.1.12559.11.10.1.3.1.3.26"/>
                             <id nullFlavor="NA"/>
-                            <code code="no-procedure-info" displayName="No information about past history of procedures" codeSystem="2.16.840.1.113883.5.1150.1" codeSystemName="IPS Absent and Unknown Data"/>
+                            <code code="no-procedure-info" displayName="No information about past history of procedures" codeSystem="2.16.840.1.113883.5.1150.1" codeSystemName="IPS Absent And Unknown Data"/>
                             <text><reference value="#Procedures_Unknown"/></text>
                             <statusCode code="completed"/>
                             <effectiveTime nullFlavor="NA" xsi:type="IVL_TS"/>
@@ -680,7 +683,7 @@
                             <participant typeCode="DEV">
                                 <participantRole classCode="MANU">
                                     <playingDevice classCode="DEV" determinerCode="INSTANCE">
-                                        <code code="no-device-info" displayName="No information about devices" codeSystem="2.16.840.1.113883.5.1150.1" codeSystemName="IPS Absent and Unknown Data"/>
+                                        <code code="no-device-info" displayName="No information about devices" codeSystem="2.16.840.1.113883.5.1150.1" codeSystemName="IPS Absent And Unknown Data"/>
                                     </playingDevice>
                                 </participantRole>
                             </participant>

--- a/national-connector/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/PatientSummaryL3MapperTest.java
+++ b/national-connector/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/PatientSummaryL3MapperTest.java
@@ -25,6 +25,7 @@ class PatientSummaryL3MapperTest {
         try {
             var cpr = "0410009234";
             var fmkresponse = FmkResponseStorage.getTestMedicineCards(cpr);
+            var ddvresponse = DdvResponseStorage.getTestVaccination(cpr);
 
             var patient = Patient.builder()
                 .id(new CdaId(Oid.DK_CPR, cpr))
@@ -55,7 +56,7 @@ class PatientSummaryL3MapperTest {
                 preferredHp,
                 patient,
                 fmkresponse,
-                null
+                ddvresponse
             );
 
             return PatientSummaryL3Mapper.model(input);

--- a/national-connector/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/PatientSummaryL3MapperTest.java
+++ b/national-connector/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/PatientSummaryL3MapperTest.java
@@ -8,6 +8,7 @@ import dk.sundhedsdatastyrelsen.ncpeh.cda.model.Patient;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.PatientSummaryL3;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.PreferredHealthProfessional;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.Telecom;
+import dk.sundhedsdatastyrelsen.ncpeh.testing.shared.DdvResponseStorage;
 import dk.sundhedsdatastyrelsen.ncpeh.testing.shared.FmkResponseStorage;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ class PatientSummaryL3MapperTest {
     static PatientSummaryL3 getModel() {
         try {
             var cpr = "0410009234";
-            var response = FmkResponseStorage.getTestMedicineCards(cpr);
+            var fmkresponse = FmkResponseStorage.getTestMedicineCards(cpr);
 
             var patient = Patient.builder()
                 .id(new CdaId(Oid.DK_CPR, cpr))
@@ -53,7 +54,7 @@ class PatientSummaryL3MapperTest {
                 "test-document-id",
                 preferredHp,
                 patient,
-                response,
+                fmkresponse,
                 null
             );
 


### PR DESCRIPTION
- Made ImmunizationMapper null-safe for optional drug attributes:
1. ATC
2. Drug form
3. Drug strength
4. Drug identifier

- Allow immunization entries to be generated when optional drug information is missing.

- Updated CDA templates to handle missing:
1. atcCode
2. formCode
3. name

- Added appropriate CDA nullFlavor handling where code values are unavailable.
- Prevented potential NPEs during immunization mapping and CDA rendering.