### PR TITLE
Add more data to the patient summary vaccination

### DIFF
--- a/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/ImmunizationMapper.java
+++ b/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/ImmunizationMapper.java
@@ -1,10 +1,10 @@
 package dk.sundhedsdatastyrelsen.ncpeh.cda;
 
+import dk.sundhedsdatastyrelsen.ncpeh.cda.model.CdaCode;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.CdaId;
 import dk.vaccinationsregister.schemas._2013._12._01.AuthorisedHealthcareProfessionalType;
 import dk.vaccinationsregister.schemas._2013._12._01.CreatedType;
 import dk.vaccinationsregister.schemas._2013._12._01.DrugStrengthType;
-import dk.sundhedsdatastyrelsen.ncpeh.cda.model.CdaCode;
 import dk.vaccinationsregister.schemas._2013._12._01.ModificatorType;
 import dk.vaccinationsregister.schemas._2013._12._01.OrganisationType;
 import dk.vaccinationsregister.schemas._2013._12._01.SSIDrugType;
@@ -47,9 +47,11 @@ public class ImmunizationMapper {
             .orElse(null);
     }
 
-    public static CdaCode getAtcCode(SSIDrugType ssiDrug) {
-        return Optional.ofNullable(ssiDrug)
-            .map(SSIDrugType::getATC)
+    public static CdaCode getAtcCode(VaccinationType vaccination) {
+        // There is an ATC code on both SSI drug and vaccine, but so far we've found that it is mostly set
+        // on the vaccine.
+        return Optional.ofNullable(vaccination.getVaccine())
+            .map(VaccineType::getATC)
             .filter(atc -> atc.getCode() != null && atc.getText() != null)
             .map(atc -> CdaCode.builder()
                 .codeSystem(Oid.ATC)

--- a/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/PatientSummaryL3Mapper.java
+++ b/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/PatientSummaryL3Mapper.java
@@ -12,16 +12,17 @@ import dk.sundhedsdatastyrelsen.ncpeh.cda.model.ActiveIngredient;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.CdaCode;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.CdaId;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.Dosage;
-import dk.sundhedsdatastyrelsen.ncpeh.cda.model.MedicationSummary;
-import dk.sundhedsdatastyrelsen.ncpeh.cda.model.MedicationSummary.MedicationItem;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.Immunizations;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.Immunizations.ImmunizationItem;
+import dk.sundhedsdatastyrelsen.ncpeh.cda.model.MedicationSummary;
+import dk.sundhedsdatastyrelsen.ncpeh.cda.model.MedicationSummary.MedicationItem;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.Patient;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.PatientSummaryL3;
 import dk.sundhedsdatastyrelsen.ncpeh.cda.model.Product;
 import dk.vaccinationsregister.schemas._2013._12._01.EffectuatedPlannedItemType;
 import dk.vaccinationsregister.schemas._2013._12._01.GetVaccinationCardResponseType;
 import dk.vaccinationsregister.schemas._2013._12._01.VaccinationType;
+import dk.vaccinationsregister.schemas._2013._12._01.VaccineType;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -112,9 +113,8 @@ public class PatientSummaryL3Mapper {
 
     public static String makeTitle(String documentId, Patient patient) {
         var patientName = patient.getName();
-        // #TODO: Figure out correct title format
         return String.format(
-            "epSOS Patient Summary %s - %s", patientName.getFullName(), documentId);
+            "Patient Summary %s - %s", patientName.getFullName(), documentId);
     }
 
     private static MedicationSummary medicationSummary(List<DrugMedicationType> medications) {
@@ -181,7 +181,6 @@ public class PatientSummaryL3Mapper {
     private static ImmunizationItem immunizationItem(VaccinationType vaccination) {
         var planned = vaccination.getEffectuatedPlannedItem();
         var drug = vaccination.getSSIDrug();
-        var vaccine = vaccination.getVaccine();
 
         return ImmunizationItem.builder()
             .immunizationId(ImmunizationMapper.immunizationId(vaccination))
@@ -190,14 +189,21 @@ public class PatientSummaryL3Mapper {
             // target disease / agent: DDV does not give a clean SNOMED target disease here.
             // Use VaccineName as text, and only code it if you have a DDV->eHDSI/SNOMED map.
             .targetDiseaseCode(null)
-            .targetDiseaseText(vaccine != null ? vaccine.getVaccineName() : null)
+            .targetDiseaseText(Optional.ofNullable(vaccination.getVaccine())
+                .map(VaccineType::getDisease)
+                .map(l -> l.stream()
+                    .map(d -> Optional.ofNullable(d.getDiseaseName()).orElse(d.getDiseaseNameDK()))
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.joining("; ")))
+                .filter(s -> !s.isEmpty())
+                .orElse(null))
 
             // Product / consumable
             .drugId(ImmunizationMapper.getDrugId(drug))
             .name(drug != null ? ImmunizationMapper.getDrugName(drug) : ImmunizationMapper.fallbackVaccineName(vaccination))
             .strength(ImmunizationMapper.getStrength(drug))
             .formCode(ImmunizationMapper.getFormCode(drug))
-            .atcCode(ImmunizationMapper.getAtcCode(drug))
+            .atcCode(ImmunizationMapper.getAtcCode(vaccination))
 
             .doseNumber(Optional.ofNullable(planned)
                 .map(EffectuatedPlannedItemType::getVaccinationPlanItemIndex)
@@ -208,9 +214,9 @@ public class PatientSummaryL3Mapper {
             .vaccinationPlanName(planned != null ? planned.getVaccinationPlanName() : null)
             .vaccinationPlanItemDescription(planned != null ? planned.getVaccinationPlanItemDescription() : null)
             .healthProfessionalIdentifier(ImmunizationMapper.getCreatedAuthorisationId(vaccination))
-            .healthProfessionalName(ImmunizationMapper.getCreatedAuthorName(vaccination))
+            .performerName(ImmunizationMapper.getCreatedAuthorName(vaccination))
             .administeringCentreIdentifier(ImmunizationMapper.getCreatedOrganisationId(vaccination))
-            .administeringCentreName(ImmunizationMapper.getCreatedOrganisationName(vaccination))
+            .performerOrganizationName(ImmunizationMapper.getCreatedOrganisationName(vaccination))
 
             .confirmedByPrescriptionServer(vaccination.isConfirmedByPrescriptionServer())
             .activeStatus(vaccination.isActiveStatus())

--- a/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Immunizations.java
+++ b/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Immunizations.java
@@ -7,6 +7,7 @@ import lombok.Value;
 import lombok.With;
 
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Value
@@ -38,13 +39,16 @@ public class Immunizations {
             return vaccinationDate == null ? null : Utils.cdaDate(vaccinationDate);
         }
 
+        public String getFriendlyVaccinationDate() {
+            return vaccinationDate == null ? null : vaccinationDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        }
+
         /**
          * hl7:code / target disease or agent.
          * Example: rabies, influenza, covid-19.
          */
         CdaCode targetDiseaseCode;
         String targetDiseaseText;
-
 
         /**
          * hl7:consumable / eHDSI Immunization SSIDrug.

--- a/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Immunizations.java
+++ b/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/Immunizations.java
@@ -83,9 +83,9 @@ public class Immunizations {
          * Can be filled from Created modificator.
          */
         String healthProfessionalIdentifier;
-        String healthProfessionalName;
+        String performerName;
         String administeringCentreIdentifier;
-        String administeringCentreName;
+        String performerOrganizationName;
 
         /**
          * Local DDV status/metadata.

--- a/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/PatientSummaryL3.java
+++ b/national-connector/cda-generator/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/cda/model/PatientSummaryL3.java
@@ -7,6 +7,7 @@ import lombok.Value;
 import lombok.With;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 @Value
 @Builder
@@ -37,4 +38,6 @@ public class PatientSummaryL3 {
 
     Immunizations immunizations;
 
+    /// Used for ids for empty sections.
+    String randomUuid = UUID.randomUUID().toString();
 }

--- a/national-connector/cda-generator/src/main/resources/templates/patient-summary-cda-l3.ftlx
+++ b/national-connector/cda-generator/src/main/resources/templates/patient-summary-cda-l3.ftlx
@@ -495,29 +495,29 @@
                     <code code="11369-6" codeSystem="2.16.840.1.113883.6.1"/>
                     <title>Immunizations</title>
                     <text>
-                    <#if (immunizations.items)?has_content>
+<#if (immunizations.items)?has_content>
                     <list>
-                    <#list immunizations.items as imm>
+    <#list immunizations.items as imm>
                         <item ID="immunization-${imm?index}">
                             <content ID="immunization-name-${imm?index}">
                                 <#if imm.name?has_content>${imm.name}</#if>
                             </content><br/>
-                            <#if (imm.vaccinationDate)?has_content>
+        <#if (imm.vaccinationDate)?has_content>
                             <content ID="immunization-date-${imm?index}">${imm.vaccinationDate}</content><br/>
-                            </#if>
-                            <#if (imm.vaccinationPlanName)?has_content>
+        </#if>
+        <#if (imm.vaccinationPlanName)?has_content>
                             <content ID="immunization-plan-${imm?index}">
                                 ${imm.vaccinationPlanName}<#if (imm.vaccinationPlanItemDescription)?has_content> - ${imm.vaccinationPlanItemDescription}</#if>
                             </content><br/>
-                            </#if>
+        </#if>
                             <paragraph>Data source: DDV 1.4.0</paragraph>
                         </item>
-                    </#list>
+    </#list>
                     </list>
-                    </#if>
+</#if>
                     </text>
-                    <#if (immunizations.items)?has_content>
-                    <#list immunizations.items as imm>
+<#if (immunizations.items)?has_content>
+    <#list immunizations.items as imm>
                     <entry typeCode="COMP">
                         <substanceAdministration classCode="SBADM" moodCode="EVN">
                             <templateId root="1.3.6.1.4.1.12559.11.10.1.3.1.3.19"/>
@@ -529,11 +529,11 @@
                                     codeSystemName="IHEActCode"/>
                             <text><reference value="#immunization-${imm?index}"/></text>
                             <statusCode code="completed"/>
-                            <#if imm.vaccinationDate?has_content>
+        <#if imm.vaccinationDate?has_content>
                             <effectiveTime value="${imm.vaccinationDate}"/>
-                            <#else>
+        <#else>
                             <effectiveTime nullFlavor="UNK"/>
-                            </#if>
+        </#if>
                             <routeCode nullFlavor="UNK"/>
                             <doseQuantity nullFlavor="UNK"/>
                             <consumable typeCode="CSM">
@@ -542,40 +542,40 @@
                                     <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.2"/>
                                     <templateId root="2.16.840.1.113883.10.20.1.53"/>
                                     <manufacturedMaterial classCode="MMAT" determinerCode="KIND">
-                                        <#if imm.atcCode??>
+        <#if imm.atcCode??>
                                         <code <@common.cdaCodeAttrs imm.atcCode />>
                                             <originalText>
                                                 <reference value="#immunization-name-${imm?index}"/>
                                             </originalText>
                                         </code>
-                                        <#else>
+        <#else>
                                         <code nullFlavor="UNK">
                                             <originalText>
                                                 <reference value="#immunization-name-${imm?index}"/>
                                             </originalText>
                                         </code>
-                                        </#if>
-                                        <#if (imm.name)?has_content>
+        </#if>
+        <#if (imm.name)?has_content>
                                         <name>${imm.name}</name>
-                                        </#if>
+        </#if>
 
-                                        <#if (imm.strength)?has_content>
+        <#if (imm.strength)?has_content>
                                         <pharm:desc>${imm.strength}</pharm:desc>
-                                        </#if>
+        </#if>
 
-                                        <#if imm.formCode??>
+        <#if imm.formCode??>
                                         <pharm:formCode <@common.cdaCodeAttrs imm.formCode />/>
-                                        <#else>
+        <#else>
                                         <pharm:formCode nullFlavor="UNK"/>
-                                        </#if>
+        </#if>
 
-                                        <#if (imm.batchNumber)?has_content>
+        <#if (imm.batchNumber)?has_content>
                                         <lotNumberText>${imm.batchNumber}</lotNumberText>
-                                        </#if>
+        </#if>
                                     </manufacturedMaterial>
                                 </manufacturedProduct>
                             </consumable>
-                            <#if imm.doseNumber??>
+        <#if imm.doseNumber??>
                             <entryRelationship typeCode="SUBJ">
                                 <observation classCode="OBS" moodCode="EVN">
                                     <templateId root="2.16.840.1.113883.10.20.1.46"/>
@@ -587,8 +587,8 @@
                                     <value xsi:type="INT" value="${imm.doseNumber}"/>
                                 </observation>
                             </entryRelationship>
-                            </#if>
-                            <#if false>
+        </#if>
+        <#if false>
                             <#-- DK does not have information on adverse reactions to the vaccination. -->
                             <entryRelationship inversionInd="false" typeCode="CAUS">
                                 <observation classCode="OBS" moodCode="EVN">
@@ -599,18 +599,18 @@
                                             codeSystem="2.16.840.1.113883.6.96"
                                             codeSystemName="SNOMED CT"/>
                                     <statusCode code="completed"/>
-                                    <#if imm.targetDiseaseCode??>
+            <#if imm.targetDiseaseCode??>
                                     <value xsi:type="CD" <@common.cdaCodeAttrs imm.targetDiseaseCode />/>
-                                    <#else>
+            <#else>
                                     <value xsi:type="CD" nullFlavor="UNK">
                                         <originalText>${imm.targetDiseaseText}</originalText>
                                     </value>
-                                    </#if>
+            </#if>
                                 </observation>
                             </entryRelationship>
-                            </#if>
-                            <#if (imm.comments)?has_content>
-                            <#list imm.comments as comment>
+        </#if>
+        <#if (imm.comments)?has_content>
+            <#list imm.comments as comment>
                             <entryRelationship typeCode="SUBJ" inversionInd="true">
                                 <act classCode="ACT" moodCode="EVN">
                                     <templateId root="1.3.6.1.4.1.12559.11.10.1.3.1.3.11"/>
@@ -619,12 +619,12 @@
                                     <statusCode code="completed"/>
                                 </act>
                             </entryRelationship>
-                            </#list>
-                            </#if>
+            </#list>
+        </#if>
                         </substanceAdministration>
                     </entry>
-                    </#list>
-                </#if>
+    </#list>
+</#if>
                 </section>
             </component>
 

--- a/national-connector/cda-generator/src/main/resources/templates/patient-summary-cda-l3.ftlx
+++ b/national-connector/cda-generator/src/main/resources/templates/patient-summary-cda-l3.ftlx
@@ -503,7 +503,7 @@
                                 <#if imm.name?has_content>${imm.name}</#if>
                             </content><br/>
         <#if (imm.vaccinationDate)?has_content>
-                            <content ID="immunization-date-${imm?index}">${imm.vaccinationDate}</content><br/>
+                            <content ID="immunization-date-${imm?index}">${imm.friendlyVaccinationDate}</content><br/>
         </#if>
         <#if (imm.vaccinationPlanName)?has_content>
                             <content ID="immunization-plan-${imm?index}">

--- a/national-connector/cda-generator/src/main/resources/templates/patient-summary-cda-l3.ftlx
+++ b/national-connector/cda-generator/src/main/resources/templates/patient-summary-cda-l3.ftlx
@@ -447,6 +447,7 @@
                     </#if>
                 </section>
             </component>
+
             <#-- Allergies -->
             <#-- We don't have allergy information registered in DK yet -->
             <component>
@@ -651,15 +652,39 @@
             </component>
 
             <#-- History of past illnesses (not required) -->
+
             <#-- Active Problems -->
-            <#-- TODO what's the status of this in DK? -->
+            <#-- Not in scope for the project. -->
             <component>
                 <section>
                     <templateId root="1.3.6.1.4.1.12559.11.10.1.3.1.2.9"/>
                     <templateId root="2.16.840.1.113883.10.20.1.11"/>
                     <code code="11450-4" codeSystem="2.16.840.1.113883.6.1" />
                     <title>Active Problems</title>
-                    <text></text>
+                    <text>
+                        <content ID="Problems_None">Active problems unknown.</content>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="1.3.6.1.4.1.12559.11.10.1.3.1.3.15"/>
+                            <templateId root="2.16.840.1.113883.10.20.1.27"/>
+                            <id nullFlavor="NA" />
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <statusCode code="active"/>
+                            <entryRelationship inversionInd="false" typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="1.3.6.1.4.1.12559.11.10.1.3.1.3.7"/>
+                                    <#-- id is mandatory here, but they recommend just writing a uuid if it doesn't exist. -->
+                                    <id root="${randomUuid}" />
+                                    <code code="404684003" codeSystem="2.16.840.1.113883.6.96" displayName="Clinical finding" codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#Problems_None"/>
+                                    </text>
+                                    <value code="no-problem-info" displayName="No information about problems" codeSystem="2.16.840.1.113883.5.1150.1" codeSystemName="IPS Absent And Unknown Data" xsi:type="CD"/>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
                 </section>
             </component>
 

--- a/national-connector/cda-generator/src/main/resources/templates/patient-summary-cda-l3.ftlx
+++ b/national-connector/cda-generator/src/main/resources/templates/patient-summary-cda-l3.ftlx
@@ -500,10 +500,12 @@
     <#list immunizations.items as imm>
                         <item ID="immunization-${imm?index}">
                             <content ID="immunization-name-${imm?index}">
-                                <#if imm.name?has_content>${imm.name}</#if>
+                                Vaccine name: ${(imm.name)!"Unknown"}
                             </content><br/>
+                            Disease: ${(imm.targetDiseaseText)!"Unknown"}<br/>
+                            ATC: ${(imm.atcCode.displayName)!"Unknown"}<br/>
         <#if (imm.vaccinationDate)?has_content>
-                            <content ID="immunization-date-${imm?index}">${imm.friendlyVaccinationDate}</content><br/>
+                            <content ID="immunization-date-${imm?index}">Date: ${imm.friendlyVaccinationDate}</content><br/>
         </#if>
         <#if (imm.vaccinationPlanName)?has_content>
                             <content ID="immunization-plan-${imm?index}">
@@ -575,6 +577,23 @@
                                     </manufacturedMaterial>
                                 </manufacturedProduct>
                             </consumable>
+        <#if (imm.performerName)?has_content || (imm.performerOrganizationName)?has_content>
+                            <performer>
+                                <assignedEntity>
+                                    <id nullFlavor="NA"/>
+            <#if (imm.performerName)?has_content>
+                                    <assignedPerson>
+                                        <name>${imm.performerName}</name>
+                                    </assignedPerson>
+            </#if>
+            <#if (imm.performerOrganizationName)?has_content>
+                                    <representedOrganization>
+                                        <name>${imm.performerOrganizationName}</name>
+                                    </representedOrganization>
+            </#if>
+                                </assignedEntity>
+                            </performer>
+        </#if>
         <#if imm.doseNumber??>
                             <entryRelationship typeCode="SUBJ">
                                 <observation classCode="OBS" moodCode="EVN">

--- a/national-connector/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/PatientSummaryL3GeneratorTest.java
+++ b/national-connector/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/PatientSummaryL3GeneratorTest.java
@@ -37,7 +37,7 @@ class PatientSummaryL3GeneratorTest {
         var oid = Oid.DK_PATIENT_SUMMARY_REPOSITORY_ID;
         var extension = "testtestL3";
         var documentId = "testtest";
-        var title = "epSOS Patient Summary Hans Christian Andersen - testtest";
+        var title = "Patient Summary Hans Christian Andersen - testtest";
         var cpr = "0410009234";
 
         var preferredHP = preferredHp("DK");
@@ -121,7 +121,7 @@ class PatientSummaryL3GeneratorTest {
         var oid = Oid.DK_PATIENT_SUMMARY_REPOSITORY_ID;
         var extension = "testtestL3";
         var documentId = "testtest";
-        var title = "epSOS Patient Summary Hans Christian Andersen - testtest";
+        var title = "Patient Summary Hans Christian Andersen - testtest";
         var cpr = "1004219992";
 
         var preferredHP = preferredHp("DK");


### PR DESCRIPTION
This fixes the empty section for active problems (one of the findings from the spring test).

Additionally adds performer, organization, disease and atc code to PS CDA (mostly just tweaking what was already there).

Makes the date in the narrative text more user friendly.