### PR TITLE
Include HCP id in MinLog requests

### DIFF
--- a/national-connector/authentication/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/EuropeanHcpId.java
+++ b/national-connector/authentication/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/EuropeanHcpId.java
@@ -1,0 +1,10 @@
+package dk.sundhedsdatastyrelsen.ncpeh.authentication;
+
+/// Identity information about a healthcare professional, for recording in MinLog.
+/// The information is extractable from an IDWS token.
+public interface EuropeanHcpId {
+    /// The "XSPA Subject" attribute value from the HCP token – i.e., the full name of the HCP
+    String subjectId();
+    ///  Country of treatment, i.e., the country in which the healthcare professional operates
+    String countryOfTreatment();
+}

--- a/national-connector/authentication/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/EuropeanHcpIdwsToken.java
+++ b/national-connector/authentication/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/EuropeanHcpIdwsToken.java
@@ -1,5 +1,7 @@
 package dk.sundhedsdatastyrelsen.ncpeh.authentication;
 
+import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XPathWrapper;
+import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XmlNamespace;
 import org.w3c.dom.Element;
 
 import java.time.Instant;
@@ -12,4 +14,20 @@ public record EuropeanHcpIdwsToken(
     String audience,
     Instant created,
     Instant expires
-) {}
+) {
+    private static final XPathWrapper xpath = new XPathWrapper(XmlNamespace.SAML);
+
+    /// Get the "XSPA Subject" attribute value from the HCP token – i.e., the full name of the HCP
+    public String subjectId() {
+        return xpath.evalString(
+            "saml:AttributeStatement/saml:Attribute[@Name='urn:oasis:names:tc:xspa:1.0:subject:subject-id']/saml:AttributeValue",
+            assertion);
+    }
+
+    ///  Get "country of treatment" from the HCP token
+    public String countryOfTreatment() {
+        return xpath.evalString(
+            "saml:AttributeStatement/saml:Attribute[@Name='urn:dk:healthcare:saml:CountryOfTreatment']/saml:AttributeValue",
+            assertion);
+    }
+}

--- a/national-connector/authentication/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/EuropeanHcpIdwsToken.java
+++ b/national-connector/authentication/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/EuropeanHcpIdwsToken.java
@@ -14,7 +14,7 @@ public record EuropeanHcpIdwsToken(
     String audience,
     Instant created,
     Instant expires
-) {
+) implements EuropeanHcpId {
     private static final XPathWrapper xpath = new XPathWrapper(XmlNamespace.SAML);
 
     /// Get the "XSPA Subject" attribute value from the HCP token – i.e., the full name of the HCP

--- a/national-connector/authentication/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/AuthenticationIT.java
+++ b/national-connector/authentication/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/AuthenticationIT.java
@@ -37,6 +37,8 @@ class AuthenticationIT {
 
         assertThat(idwsToken.audience(), is("https://fmk"));
         assertThat(idwsToken.assertion(), notNullValue());
+        assertThat(idwsToken.subjectId(), is("John House"));
+        assertThat(idwsToken.countryOfTreatment(), is("DK"));
     }
 
     @Test
@@ -46,6 +48,8 @@ class AuthenticationIT {
 
         assertThat(idwsToken.audience(), is("https://fmk"));
         assertThat(idwsToken.assertion(), notNullValue());
+        assertThat(idwsToken.subjectId(), is("Helvi Inkinen"));
+        assertThat(idwsToken.countryOfTreatment(), is("FI"));
     }
 
     @Test

--- a/national-connector/epps-application/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/Controller.java
+++ b/national-connector/epps-application/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/Controller.java
@@ -136,9 +136,7 @@ public class Controller {
                 params.getPatientId(),
                 params.getDocumentId(),
                 this.getIdwsToken(params.getSoapHeader(), Audience.FMK),
-                this.getIdwsToken(params.getSoapHeader(), Audience.DDV),
-                // TODO pick out the right identity from the soap header.
-                "MT^94e9cd39-f9c2-434c-9069-ee8bd81b11c1");
+                this.getIdwsToken(params.getSoapHeader(), Audience.DDV));
         }
 
         throw new ServerErrorException("Unknown repository id " + repoId, null);

--- a/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/InformationCardService.java
+++ b/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/InformationCardService.java
@@ -1,5 +1,6 @@
 package dk.sundhedsdatastyrelsen.ncpeh.service;
 
+import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpId;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpIdwsToken;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.PublicException;
@@ -104,11 +105,11 @@ public class InformationCardService {
      * Call Fælles Stamkort (FSK) to get an information card.
      * @param uniqueDocumentId id for the information card
      * @param patientId (for logging) patient id
-     * @param hcpIdwsToken (for logging) IDWS token with information about the healthcare professional.
+     * @param hcpId (for logging) IDWS token with information about the healthcare professional.
      *                   Not used for placing calls, so audience is irrelevant.
      * @return the information card in XML form
      */
-    public Document getInformationCard(String uniqueDocumentId, String patientId, EuropeanHcpIdwsToken hcpIdwsToken) {
+    public Document getInformationCard(String uniqueDocumentId, String patientId, EuropeanHcpId hcpId) {
         try {
             var documentId = splitUniqueIdToRepositoryIdAndDocumentId(uniqueDocumentId);
             final var request = RetrieveDocumentSetRequestType.builder()
@@ -119,7 +120,7 @@ public class InformationCardService {
 
             //Log that we looked up the data on the fælles stamkort, due to using the organisational endpoint
             var cpr = PatientIdMapper.toCpr(patientId);
-            minLogService.logEventOnPatient(cpr, "Fælles Stamkort opslag", hcpIdwsToken);
+            minLogService.logEventOnPatient(cpr, "Fælles Stamkort opslag", hcpId);
 
             //The endpoints does not (in the near future) support IDWS, so we have to use the organisatorial endpoint.
             var fskResponse = fskClient.getDocument(request, systemCaller);

--- a/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/InformationCardService.java
+++ b/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/InformationCardService.java
@@ -1,7 +1,6 @@
 package dk.sundhedsdatastyrelsen.ncpeh.service;
 
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpId;
-import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpIdwsToken;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.PublicException;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XmlException;

--- a/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/InformationCardService.java
+++ b/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/InformationCardService.java
@@ -1,5 +1,6 @@
 package dk.sundhedsdatastyrelsen.ncpeh.service;
 
+import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpIdwsToken;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.PublicException;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XmlException;
@@ -99,7 +100,15 @@ public class InformationCardService {
         }
     }
 
-    public Document getInformationCard(String uniqueDocumentId, String patientId, String europeanHealthProfessionalId) {
+    /**
+     * Call Fælles Stamkort (FSK) to get an information card.
+     * @param uniqueDocumentId id for the information card
+     * @param patientId (for logging) patient id
+     * @param hcpIdwsToken (for logging) IDWS token with information about the healthcare professional.
+     *                   Not used for placing calls, so audience is irrelevant.
+     * @return the information card in XML form
+     */
+    public Document getInformationCard(String uniqueDocumentId, String patientId, EuropeanHcpIdwsToken hcpIdwsToken) {
         try {
             var documentId = splitUniqueIdToRepositoryIdAndDocumentId(uniqueDocumentId);
             final var request = RetrieveDocumentSetRequestType.builder()
@@ -110,7 +119,7 @@ public class InformationCardService {
 
             //Log that we looked up the data on the fælles stamkort, due to using the organisational endpoint
             var cpr = PatientIdMapper.toCpr(patientId);
-            minLogService.logEventOnPatient(cpr, "Fælles Stamkort opslag", europeanHealthProfessionalId);
+            minLogService.logEventOnPatient(cpr, "Fælles Stamkort opslag", hcpIdwsToken);
 
             //The endpoints does not (in the near future) support IDWS, so we have to use the organisatorial endpoint.
             var fskResponse = fskClient.getDocument(request, systemCaller);

--- a/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/MinLogService.java
+++ b/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/MinLogService.java
@@ -6,6 +6,7 @@ import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registra
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.RegistrationRequestType;
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.SourceForEntryType;
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.UserPersonIdSourceType;
+import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpId;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpIdwsToken;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import dk.sundhedsdatastyrelsen.ncpeh.client.MinLogClient;
@@ -200,7 +201,7 @@ public class MinLogService implements AutoCloseable {
     public void logEventOnPatient(
         String cpr,
         String eventText,
-        EuropeanHcpIdwsToken hcpIdwsToken
+        EuropeanHcpId hcpIdwsToken
     ) {
         logEventOnPatient(
             cpr,

--- a/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/MinLogService.java
+++ b/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/MinLogService.java
@@ -7,7 +7,6 @@ import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registra
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.SourceForEntryType;
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.UserPersonIdSourceType;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpId;
-import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpIdwsToken;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import dk.sundhedsdatastyrelsen.ncpeh.client.MinLogClient;
 import dk.sundhedsdatastyrelsen.ncpeh.jobqueue.JobQueue;
@@ -201,12 +200,12 @@ public class MinLogService implements AutoCloseable {
     public void logEventOnPatient(
         String cpr,
         String eventText,
-        EuropeanHcpId hcpIdwsToken
+        EuropeanHcpId hcpId
     ) {
         logEventOnPatient(
             cpr,
             eventText,
-            "%s - %s".formatted(hcpIdwsToken.countryOfTreatment(), hcpIdwsToken.subjectId())
+            "%s - %s".formatted(hcpId.countryOfTreatment(), hcpId.subjectId())
         );
     }
 

--- a/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/MinLogService.java
+++ b/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/MinLogService.java
@@ -6,6 +6,7 @@ import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registra
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.RegistrationRequestType;
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.SourceForEntryType;
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.UserPersonIdSourceType;
+import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpIdwsToken;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
 import dk.sundhedsdatastyrelsen.ncpeh.client.MinLogClient;
 import dk.sundhedsdatastyrelsen.ncpeh.jobqueue.JobQueue;
@@ -191,6 +192,21 @@ public class MinLogService implements AutoCloseable {
             return failedJobList;
         }
         return Collections.emptyList(); //If nothing failed, we return an empty list of failed LogEvents
+    }
+
+    /// Register MinLog event.
+    /// Extracts healthcare professional identification from an IDWS token.
+    /// The event will be added to a queue and handled in a separate thread.
+    public void logEventOnPatient(
+        String cpr,
+        String eventText,
+        EuropeanHcpIdwsToken hcpIdwsToken
+    ) {
+        logEventOnPatient(
+            cpr,
+            eventText,
+            "%s - %s".formatted(hcpIdwsToken.countryOfTreatment(), hcpIdwsToken.subjectId())
+        );
     }
 
     /// Register MinLog event.  The event will be added to a queue and handled in a separate thread.

--- a/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PatientSummaryService.java
+++ b/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PatientSummaryService.java
@@ -86,16 +86,14 @@ public class PatientSummaryService {
         return new DocumentAssociationForPatientSummaryDocumentMetadataDto(l3, l1);
     }
 
-    // TODO Left in the caller, because I think we will need it later.
     @WithSpan
     public List<EpsosDocumentDto> getPatientSummary(
         String patientId,
         String rootedDocumentId,
         EuropeanHcpIdwsToken fmkToken,
-        EuropeanHcpIdwsToken ddvToken,
-        String europeanHealthProfessionalId
+        EuropeanHcpIdwsToken ddvToken
     ) {
-        var input = assembleInput(patientId, europeanHealthProfessionalId, rootedDocumentId, fmkToken, ddvToken);
+        var input = assembleInput(patientId, rootedDocumentId, fmkToken, ddvToken);
         try {
             var documentLevel = DocumentIdMapper.parseDocumentLevel(rootedDocumentId);
             var cda = switch (documentLevel) {
@@ -112,14 +110,14 @@ public class PatientSummaryService {
     @WithSpan
     private PatientSummaryInput assembleInput(
         String patientId,
-        String europeanHealthProfessionalId,
         String docId,
         EuropeanHcpIdwsToken fmkToken,
         EuropeanHcpIdwsToken ddvToken
     ) {
         var cpr = PatientIdMapper.toCpr(patientId);
         var availableInformationCards = informationCardService.findInformationCardDetails(patientId);
-        var informationCard = informationCardService.getInformationCard(availableInformationCards.getFirst(), patientId, europeanHealthProfessionalId);
+        var minLogHcpId = "%s - %s".formatted(fmkToken.countryOfTreatment(), fmkToken.subjectId());
+        var informationCard = informationCardService.getInformationCard(availableInformationCards.getFirst(), patientId, minLogHcpId);
 
         var medicationCardRequest = GetMedicineCardRequestType.builder()
             .withPersonIdentifier().withSource("CPR").withValue(cpr).end()

--- a/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PatientSummaryService.java
+++ b/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/PatientSummaryService.java
@@ -116,8 +116,7 @@ public class PatientSummaryService {
     ) {
         var cpr = PatientIdMapper.toCpr(patientId);
         var availableInformationCards = informationCardService.findInformationCardDetails(patientId);
-        var minLogHcpId = "%s - %s".formatted(fmkToken.countryOfTreatment(), fmkToken.subjectId());
-        var informationCard = informationCardService.getInformationCard(availableInformationCards.getFirst(), patientId, minLogHcpId);
+        var informationCard = informationCardService.getInformationCard(availableInformationCards.getFirst(), patientId, fmkToken);
 
         var medicationCardRequest = GetMedicineCardRequestType.builder()
             .withPersonIdentifier().withSource("CPR").withValue(cpr).end()

--- a/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Fsk.java
+++ b/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Fsk.java
@@ -1,5 +1,6 @@
 package dk.sundhedsdatastyrelsen.ncpeh.testing.shared;
 
+import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpId;
 import dk.sundhedsdatastyrelsen.ncpeh.client.FskClient;
 
 /**
@@ -15,7 +16,17 @@ public class Fsk {
 
     public static final String documentJensJensenFskResponse = "1.2.208.176.43210.8.10.12^aa575bf2-fde6-434c-bd0c-ccf5a512680d";
 
-    public static final String germanDoctor = "DE^ad93e02e-6732-4a06-ad73-6c491b20f4f9";
+    public static final EuropeanHcpId germanDoctor = new EuropeanHcpId() {
+        @Override
+        public String subjectId() {
+            return "Hans Gruber";
+        }
+
+        @Override
+        public String countryOfTreatment() {
+            return "DE";
+        }
+    };
 
     private static FskClient fskClient;
 


### PR DESCRIPTION
Until now we have used a hardcoded dummy ID for MinLog event registrations.

This PR changes the MinLog API to take an IDWS token representing the HCP and extracting the ID string from the token.

The formatting of the ID string should match what FMK/DDV does, but I have not been able to make FMK write events to MinLog on test2.