### PR TITLE
add disease original text and handle deleted vaccinations

### DIFF
--- a/national-connector/cda-generator/src/main/resources/templates/patient-summary-cda-l3.ftlx
+++ b/national-connector/cda-generator/src/main/resources/templates/patient-summary-cda-l3.ftlx
@@ -499,10 +499,11 @@
                         <list>
     <#list immunizations.items as imm>
                             <item ID="immunization-${imm?index}">
-                                <content ID="immunization-name-${imm?index}">
-                                    Vaccine name: ${(imm.name)!"Unknown"}
-                                </content><br/>
-                                Disease: ${(imm.targetDiseaseText)!"Unknown"}<br/>
+        <#if !imm.activeStatus>
+                                -- Not administered --<br/>
+        </#if>
+                                Vaccine name: <content ID="immunization-name-${imm?index}">${(imm.name)!"Unknown"}</content><br/>
+                                Disease: <content ID="imm-disease-${imm?index}">${(imm.targetDiseaseText)!"Unknown"}</content><br/>
                                 ATC: ${(imm.atcCode.code)!"Unknown"}<br/>
         <#if (imm.vaccinationDate)?has_content>
                                 <content ID="immunization-date-${imm?index}">Date: ${imm.friendlyVaccinationDate}</content><br/>
@@ -530,7 +531,7 @@
                                     codeSystem="1.3.5.1.4.1.19376.1.5.3.2"
                                     codeSystemName="IHEActCode"/>
                             <text><reference value="#immunization-${imm?index}"/></text>
-                            <statusCode code="completed"/>
+                            <statusCode code="${imm.activeStatus?then("completed", "cancelled")}"/>
         <#if imm.vaccinationDate?has_content>
                             <effectiveTime value="${imm.vaccinationDate}"/>
         <#else>
@@ -594,6 +595,18 @@
                                 </assignedEntity>
                             </performer>
         </#if>
+                            <participant typeCode="IND">
+                                <participantRole classCode="AGNT">
+                                    <code nullFlavor="UNK">
+        <#if (imm.targetDiseaseText)?has_content>
+                                        <originalText>
+                                            <reference value="#imm-disease-${imm?index}" />
+                                        </originalText>
+        </#if>
+                                    </code>
+                                    <playingEntity classCode="ENT" />
+                                </participantRole>
+                            </participant>
         <#if imm.doseNumber??>
                             <entryRelationship typeCode="SUBJ">
                                 <observation classCode="OBS" moodCode="EVN">

--- a/national-connector/testing-shared/src/main/resources/test-vaccinations/vaccination-card-0410009234.xml
+++ b/national-connector/testing-shared/src/main/resources/test-vaccinations/vaccination-card-0410009234.xml
@@ -76,7 +76,7 @@
         <DosageOptionIdentifier>32115515737</DosageOptionIdentifier>
         <EffectuatedDateTime>2024-06-05T22:00:00Z</EffectuatedDateTime>
         <ConfirmedByPrescriptionServer>false</ConfirmedByPrescriptionServer>
-        <ActiveStatus>true</ActiveStatus>
+        <ActiveStatus>false</ActiveStatus>
         <IsPrevious>false</IsPrevious>
     </Vaccination>
     <Vaccination>


### PR DESCRIPTION
This adds the disease original text to the CDA, and marks deleted immunizations as such. We don't have the disease coded in DK.