### PR TITLE
Changed EP to use the stored prescriptions and drug medications instead of the dynamic ones

### DIFF
--- a/national-connector/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL1GeneratorTest.java
+++ b/national-connector/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL1GeneratorTest.java
@@ -26,7 +26,7 @@ public class EPrescriptionL1GeneratorTest {
     @ParameterizedTest
     @ValueSource(strings = {"0201909309"})
     public void testCdaValidity(String cpr) throws Exception {
-        var prescription = FmkResponseStorage.storedPrescriptions(cpr);
+        var prescription = FmkResponseStorage.getTestPrescriptions(cpr);
         Assertions.assertFalse(prescription.getPrescription().isEmpty());
         var xmlString = EPrescriptionL1Generator.generate(new EPrescriptionL3Input(
             prescription, 0, null, "FIN", 1, "Manufacturer", "2026-01"));

--- a/national-connector/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3GeneratorTest.java
+++ b/national-connector/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3GeneratorTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.*;
 
 class EPrescriptionL3GeneratorTest {
     @Test
-    void generateTest() throws TemplateException, IOException {
+    void generateTest() {
         var model = EPrescriptionL3MapperTest.getModel();
         var cda = EPrescriptionL3Generator.generate(model);
         Assertions.assertNotNull(cda);
@@ -32,8 +32,8 @@ class EPrescriptionL3GeneratorTest {
     @Test
     void testNullProductPackageCodeValue() throws Exception {
         var cpr = "0201909309"; //Test person with packagecode correctly filled in
-        var prescription = FmkResponseStorage.storedPrescriptions(cpr);
-        var medication = FmkResponseStorage.storedDrugMedications(cpr);
+        var prescription = FmkResponseStorage.getTestPrescriptions(cpr);
+        var medication = FmkResponseStorage.getTestDrugMedications(cpr);
         Assertions.assertFalse(prescription.getPrescription().isEmpty());
         var input = new EPrescriptionL3Input(prescription, 0, medication, "FIN", 1, "Manufacturer", "2026-01");
         var epL3 = EPrescriptionL3Mapper.model(input);
@@ -62,7 +62,7 @@ class EPrescriptionL3GeneratorTest {
     @MethodSource("e2eTestCprs")
     void testCdaValidity(String cpr) throws Exception {
         var prescription = FmkResponseStorage.getTestPrescriptions(cpr);
-        var medication = FmkResponseStorage.getTestMedications(cpr);
+        var medication = FmkResponseStorage.getTestDrugMedications(cpr);
         Assertions.assertFalse(prescription.getPrescription().isEmpty());
         var prescriptions = prescription.getPrescription();
         for (int prescriptionindex = 0; prescriptionindex < prescriptions.size(); prescriptionindex++) {

--- a/national-connector/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3MapperTest.java
+++ b/national-connector/cda-generator/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/cda/EPrescriptionL3MapperTest.java
@@ -11,9 +11,9 @@ import static org.hamcrest.Matchers.*;
 class EPrescriptionL3MapperTest {
     static EPrescriptionL3 getModel() {
         try {
-            var response = FmkResponseStorage.storedPrescriptions(FmkResponseStorage.rawResponseCprs().get(2));
-            var medicationResponse = FmkResponseStorage.storedDrugMedications(FmkResponseStorage.rawResponseCprs()
-                .get(2));
+            var cpr = "0201909309";
+            var response = FmkResponseStorage.getTestPrescriptions(cpr);
+            var medicationResponse = FmkResponseStorage.getTestDrugMedications(cpr);
 
             return EPrescriptionL3Mapper.model(new EPrescriptionL3Input(response, 0, medicationResponse, "FIN", 1, "Manufacturer", "2025-01"));
         } catch (Exception e) {
@@ -41,12 +41,12 @@ class EPrescriptionL3MapperTest {
 
     @Test
     void nullSubpackagesIsHandled() throws Exception {
-        var cpr = FmkResponseStorage.rawResponseCprs().get(2);
+        var cpr = "0201909309";
         var model = EPrescriptionL3Mapper.model(
             new EPrescriptionL3Input(
-                FmkResponseStorage.storedPrescriptions(cpr),
+                FmkResponseStorage.getTestPrescriptions(cpr),
                 0,
-                FmkResponseStorage.storedDrugMedications(cpr),
+                FmkResponseStorage.getTestDrugMedications(cpr),
                 "FIN",
                 null,
                 "Manufacturer",

--- a/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/FmkResponseStorage.java
+++ b/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/FmkResponseStorage.java
@@ -154,7 +154,7 @@ public class FmkResponseStorage {
         return readStoredPrescriptions(name, resourceDir);
     }
 
-    public static GetDrugMedicationResponseType getTestMedications(String cpr) throws JAXBException {
+    public static GetDrugMedicationResponseType getTestDrugMedications(String cpr) throws JAXBException {
         return storedDrugMedications(cpr, testDataDir);
     }
 


### PR DESCRIPTION
Changed EPresciptionL1, L3 and Mapper testcases to use get the self-stored testdata instead of the potential changing ones