### PR TITLE
Bump all Github Action dependencies

### DIFF
--- a/.github/workflows/build-epps-image.yml
+++ b/.github/workflows/build-epps-image.yml
@@ -24,17 +24,17 @@ jobs:
       id-token: write
     steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to the Container registry
-      uses: docker/login-action@v3.2.0
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     - name: Generate docker-bake.hcl
       run: |

--- a/.github/workflows/build-ncp-docker-images.yml
+++ b/.github/workflows/build-ncp-docker-images.yml
@@ -24,13 +24,13 @@ jobs:
       id-token: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to the Container registry
-      uses: docker/login-action@v3.2.0
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}

--- a/.github/workflows/deploy-country-a-to-server.yml
+++ b/.github/workflows/deploy-country-a-to-server.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.DEV_SSH_PRIVATE_KEY }}
 
@@ -38,8 +38,8 @@ jobs:
             echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
             # 3. Pull the Docker images (if any are specified in the docker-compose.yml)
-            docker compose pull 
+            docker compose pull
 
             # 4. Deploy the services
-            docker compose up -d 
+            docker compose up -d
           EOF

--- a/.github/workflows/deploy-ncp-to-server.yml
+++ b/.github/workflows/deploy-ncp-to-server.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.DEV_SSH_PRIVATE_KEY }}
 
@@ -38,8 +38,8 @@ jobs:
             echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
             # 3. Pull the Docker images (if any are specified in the docker-compose.yml)
-            docker compose pull 
+            docker compose pull
 
             # 4. Deploy the services
-            docker compose up -d 
+            docker compose up -d
           EOF

--- a/.github/workflows/nightly-tsam-sync.yml
+++ b/.github/workflows/nightly-tsam-sync.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.DEV_SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,11 +16,11 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 5 # for commit history
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: temurin
@@ -70,7 +70,7 @@ jobs:
         run: docker logout ghcr.io
 
       - name: Upload test files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ep-and-ed-files
           path: target/test-files/
@@ -89,7 +89,7 @@ jobs:
           E2E_TRAINING_HOST: ${{ secrets.E2E_TRAINING_HOST }}
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v6
         if: success() || failure() # always run even if the previous step fails
         with:
           report_paths: 'national-connector/integration-tests/target/failsafe-reports/TEST-*.xml'
@@ -107,7 +107,7 @@ jobs:
 
       - name: Post to a Slack channel
         id: slack
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@v3
         if: failure() # only post on slack if tests fail
         # See: https://github.com/slackapi/slack-github-action?tab=readme-ov-file#technique-2-slack-app
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
   compare-openapi-files:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Compare API Definition files
       run: cmp -s "./NCP/openncp-national-connector/src/main/resources/country-a-api.yml" "./national-connector/epps-api/epps-ncp-api/src/main/openapi/ncp.yaml"
 
@@ -22,19 +22,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: 21
         distribution: temurin
         cache: maven
 
     - name: Cache SonarQube Cloud Packages
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
@@ -48,7 +48,7 @@ jobs:
       run: mvn --batch-mode verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=Sundhedsdatastyrelsen_ehdsi
 
     - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v4
+      uses: mikepenz/action-junit-report@v6
       if: success() || failure() # always run even if the previous step fails
       with:
         report_paths: '**/target/surefire-reports/TEST-*.xml'


### PR DESCRIPTION
This should get us up to Node 24 on all tasks and rid us of the Node 20 deprecation warnings.