### PR TITLE
MinLog log entries for PS

### DIFF
--- a/national-connector/authentication/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/EuropeanHcpId.java
+++ b/national-connector/authentication/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/EuropeanHcpId.java
@@ -5,6 +5,16 @@ package dk.sundhedsdatastyrelsen.ncpeh.authentication;
 public interface EuropeanHcpId {
     /// The "XSPA Subject" attribute value from the HCP token – i.e., the full name of the HCP
     String subjectId();
+
     ///  Country of treatment, i.e., the country in which the healthcare professional operates
     String countryOfTreatment();
+
+    /// "XSPA Organization Id"
+    String organizationId();
+
+    /// "XSPA Organization"
+    String organizationName();
+
+    /// Point of care / "XSPA Locality"
+    String pointOfCare();
 }

--- a/national-connector/authentication/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/EuropeanHcpIdwsToken.java
+++ b/national-connector/authentication/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/EuropeanHcpIdwsToken.java
@@ -2,6 +2,7 @@ package dk.sundhedsdatastyrelsen.ncpeh.authentication;
 
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XPathWrapper;
 import dk.sundhedsdatastyrelsen.ncpeh.base.utils.XmlNamespace;
+import lombok.NonNull;
 import org.w3c.dom.Element;
 
 import java.time.Instant;
@@ -18,6 +19,8 @@ public record EuropeanHcpIdwsToken(
     private static final XPathWrapper xpath = new XPathWrapper(XmlNamespace.SAML);
 
     /// Get the "XSPA Subject" attribute value from the HCP token – i.e., the full name of the HCP
+    @Override
+    @NonNull
     public String subjectId() {
         return xpath.evalString(
             "saml:AttributeStatement/saml:Attribute[@Name='urn:oasis:names:tc:xspa:1.0:subject:subject-id']/saml:AttributeValue",
@@ -25,9 +28,39 @@ public record EuropeanHcpIdwsToken(
     }
 
     ///  Get "country of treatment" from the HCP token
+    @Override
+    @NonNull
     public String countryOfTreatment() {
         return xpath.evalString(
             "saml:AttributeStatement/saml:Attribute[@Name='urn:dk:healthcare:saml:CountryOfTreatment']/saml:AttributeValue",
             assertion);
+    }
+
+    ///  Get "XSPA Organization ID" from the HCP token
+    @Override
+    @NonNull
+    public String organizationId() {
+        return xpath.evalString(
+            "saml:AttributeStatement/saml:Attribute[@Name='urn:oasis:names:tc:xspa:1.0:subject:organization-id']/saml:AttributeValue",
+            assertion);
+    }
+
+    ///  Get "XSPA Locality" from the HCP token, i.e., the name of the place where treatment is taking place.
+    @Override
+    @NonNull
+    public String pointOfCare() {
+        return xpath.evalString(
+            "saml:AttributeStatement/saml:Attribute[@Name='urn:oasis:names:tc:xspa:1.0:environment:locality']/saml:AttributeValue",
+            assertion);
+    }
+
+    ///  Get "XSPA Organization" from the HCP token.  This is an optional value, we might not receive it.
+    /// It should only be filled when it differs from "point of care"/"locality".
+    @Override
+    public String organizationName() {
+        var node = xpath.evalNode(
+            "saml:AttributeStatement/saml:Attribute[@Name='urn:oasis:names:tc:xspa:1.0:subject:organization']/saml:AttributeValue",
+            assertion);
+        return node == null ? null : node.getTextContent();
     }
 }

--- a/national-connector/authentication/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/AuthenticationIT.java
+++ b/national-connector/authentication/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/authentication/AuthenticationIT.java
@@ -39,6 +39,9 @@ class AuthenticationIT {
         assertThat(idwsToken.assertion(), notNullValue());
         assertThat(idwsToken.subjectId(), is("John House"));
         assertThat(idwsToken.countryOfTreatment(), is("DK"));
+        assertThat(idwsToken.pointOfCare(), is("eHDSI EU Testing MedCare Center"));
+        assertThat(idwsToken.organizationId(), is("urn:hl7ii:1.2.3.4:ABCD"));
+        assertThat(idwsToken.organizationName(), is("eHealth OpenNCP EU Portal"));
     }
 
     @Test
@@ -50,6 +53,9 @@ class AuthenticationIT {
         assertThat(idwsToken.assertion(), notNullValue());
         assertThat(idwsToken.subjectId(), is("Helvi Inkinen"));
         assertThat(idwsToken.countryOfTreatment(), is("FI"));
+        assertThat(idwsToken.pointOfCare(), is("Kela pd3 as.tst"));
+        assertThat(idwsToken.organizationId(), is("urn:oid:1.2.246.556.13001.48"));
+        assertThat(idwsToken.organizationName(), nullValue());
     }
 
     @Test

--- a/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/MinLogService.java
+++ b/national-connector/epps-service/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/service/MinLogService.java
@@ -2,9 +2,9 @@ package dk.sundhedsdatastyrelsen.ncpeh.service;
 
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.DestinationForEntryForRegistrationType;
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.LogDataEntryForRegistrationType;
+import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.OrganisationIdSourcePredefinedType;
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.PersonIdSourceType;
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.RegistrationRequestType;
-import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.SourceForEntryType;
 import dk.sundhedsdatastyrelsen.minlog.xml_schema._2025._03._12.minlog2_registration.UserPersonIdSourceType;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.EuropeanHcpId;
 import dk.sundhedsdatastyrelsen.ncpeh.authentication.NspDgwsIdentity;
@@ -12,7 +12,9 @@ import dk.sundhedsdatastyrelsen.ncpeh.client.MinLogClient;
 import dk.sundhedsdatastyrelsen.ncpeh.jobqueue.JobQueue;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.metrics.ObservableLongUpDownCounter;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
@@ -130,11 +132,22 @@ public class MinLogService implements AutoCloseable {
     ///   you add new nullable fields, or
     /// - you make sure the queue is empty before applying the update.
     public record LogEvent(
-        String citizenCpr,
-        String eventText,
-        String hcpId,
-        Instant timestamp
+        @NonNull String citizenCpr,
+        @NonNull String eventText,
+        @NonNull String hcpName,
+        @NonNull String hcpId,
+        @NonNull String organisationId,
+        @NonNull String organisationName,
+        @NonNull Instant timestamp
     ) {}
+
+    private static String truncate(@NonNull String value, int maxLength, String parameterName) {
+        var result = StringUtils.truncate(value, maxLength);
+        if (!value.equals(result)) {
+            log.warn("MinLog parameter truncated: \"{}\". Length was {}, maximum length is {}.", parameterName, value.length(), maxLength);
+        }
+        return result;
+    }
 
     /// A method to send logevents to MinLog. Since this is the last step for the events that succeed, we return the failed statements
     ///
@@ -145,28 +158,28 @@ public class MinLogService implements AutoCloseable {
         var requestBuilder = RegistrationRequestType.builder();
         for (var job : logEventJobs) {
             var payload = job.payload();
-            var source = SourceForEntryType.builder()
-                .withSystemName("DK-NCPeH")
-                .withSource()
-                .withSystemName("DK-NCPeH")
-                .build();
             var destination = DestinationForEntryForRegistrationType.builder()
-                .withSystemName("NCPeH") // TODO Replace with actual country we sent it to?
-                .withActivity(payload.eventText())
+                .withSystemName("DK-NCPeH")
+                .withActivity(truncate(payload.eventText(), 75, "Activity")) // "Streng, max længde på 75 tegn"
                 .withDateTime(Utils.xmlGregorianCalendar(payload.timestamp()))
                 .withPersonIdentifier()
                 .withSource(PersonIdSourceType.CPR)
                 .withValue(payload.citizenCpr())
                 .end()
-                .withUserPersonName("TODO") // TODO include name which must be max 50 chars long (bytes? unicode code points?)
+                .withUserPersonName(truncate(payload.hcpName(), 50, "UserPersonName")) // "Streng med max længde 50 tegn"
                 .withUserPersonIdentifier()
                 .withSource(UserPersonIdSourceType.EUROPEAN_HEALTHCARE_PROFESSIONAL)
-                .withValue(payload.hcpId()) // TODO react to id's exceeding the 200 char limit
+                .withValue(truncate(payload.hcpId, 200, "UserPersonIdentifier")) // "Streng af længde 200"
                 .end()
                 .withSequenceNumber(job.id().toString())
+                .withOrganisationId()
+                .withSource(OrganisationIdSourcePredefinedType.EUROPEAN_HEALTHCARE_ORGANISATION)
+                .withValue(truncate(payload.organisationId(), 200, "OrganisationId")) // "Streng på max 200 tegn"
+                .end()
+                .withOrganisationName(truncate(payload.organisationName(), 200, "OrganisationName")) // "Streng med max længde 200"
                 .build();
+
             requestBuilder.addLogDataEntry(LogDataEntryForRegistrationType.builder()
-                .withSource(source)
                 .withDestination(destination)
                 .build());
         }
@@ -202,27 +215,30 @@ public class MinLogService implements AutoCloseable {
         String eventText,
         EuropeanHcpId hcpId
     ) {
-        logEventOnPatient(
-            cpr,
-            eventText,
-            "%s - %s".formatted(hcpId.countryOfTreatment(), hcpId.subjectId())
-        );
+        logEventOnPatient(createLogEvent(cpr, eventText, hcpId));
     }
 
-    /// Register MinLog event.  The event will be added to a queue and handled in a separate thread.
-    public void logEventOnPatient(
-        String cpr,
-        String eventText,
-        String europeanHealthProfessionalId
-    ) {
-        var logEvent = new LogEvent(
+    /// Register MinLog event.
+    /// The event will be added to a queue and handled in a separate thread.
+    public void logEventOnPatient(LogEvent logEvent) {
+        jobQueue.enqueue(logEvent);
+        log.debug("Enqueued MinLog event: {}", logEvent.eventText());
+    }
+
+    private LogEvent createLogEvent(String cpr, String eventText, EuropeanHcpId hcpId) {
+        return new LogEvent(
             cpr,
             eventText,
-            europeanHealthProfessionalId,
+            hcpId.subjectId(),
+            // There is currently no documentation of this format on nspop, but it is enforced in the MinLog2 code:
+            // https://git.nspop.dk/projects/COM/repos/minlog/browse/kafka-proxy/src/main/java/dk/nsp/minlog2/kafkaproxy/validation/LogEntryValidator.java#131
+            "%s:%s".formatted(hcpId.countryOfTreatment(), hcpId.subjectId()),
+            hcpId.organizationId(),
+            // Organization name is only non-null if different from "point of care".
+            hcpId.organizationName() == null
+                ? hcpId.pointOfCare()
+                : "%s/%s".formatted(hcpId.organizationName(), hcpId.pointOfCare()),
             Instant.now());
-
-        jobQueue.enqueue(logEvent);
-        log.debug("Enqueued MinLog event: {}", eventText);
     }
 
     /// Stops the scheduler which stop the MinLog registration.

--- a/national-connector/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/MinLogIT.java
+++ b/national-connector/integration-tests/src/test/java/dk/sundhedsdatastyrelsen/ncpeh/MinLogIT.java
@@ -9,6 +9,7 @@ import org.springframework.jdbc.datasource.SingleConnectionDataSource;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
+import java.time.Instant;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -36,7 +37,16 @@ class MinLogIT {
         try (var ds = ds();
              var service = minLogService(ds)) {
             var q = JobQueue.open(ds, "minlog", null, null);
-            service.logEventOnPatient(MinLog.CPR_JENS_JENSEN_READ_ONLY, "integrationstest", "DE^ad93e02e-6732-4a06-ad73-6c491b20f4f9");
+            var logEvent = new MinLogService.LogEvent(
+                MinLog.CPR_JENS_JENSEN_READ_ONLY,
+                "integrationtest",
+                "Name of Doctor",
+                "DE:Name of Doctor",
+                "id-of-organization",
+                "Name of Organization",
+                Instant.now()
+            );
+            service.logEventOnPatient(logEvent);
             assertThat(q.size(), is(1L));
             assertDoesNotThrow(service::sendBatch);
             assertThat(q.size(), is(0L));

--- a/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Fsk.java
+++ b/national-connector/testing-shared/src/main/java/dk/sundhedsdatastyrelsen/ncpeh/testing/shared/Fsk.java
@@ -26,6 +26,21 @@ public class Fsk {
         public String countryOfTreatment() {
             return "DE";
         }
+
+        @Override
+        public String organizationId() {
+            return "urn:oid:9999.9999.9999";
+        }
+
+        @Override
+        public String organizationName() {
+            return null;
+        }
+
+        @Override
+        public String pointOfCare() {
+            return "Apotheke Gruber";
+        }
     };
 
     private static FskClient fskClient;


### PR DESCRIPTION
Ensure that the MinLog entries from patient summary lookup requests use all the relevant data about the healthcare professional.

The HCP id must use the format `<countrycode>:<hcp-id>` to pass MinLog validation, see https://git.nspop.dk/projects/COM/repos/minlog/browse/kafka-proxy/src/main/java/dk/nsp/minlog2/kafkaproxy/validation/LogEntryValidator.java#131